### PR TITLE
Use quotes for type annotations

### DIFF
--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 class MultiSpecDataset(torch.utils.data.Dataset):
-    def __init__(self, cfg, data: pd.DataFrame, phase: str, transform=None):
+    def __init__(self, cfg, data: "pd.DataFrame", phase: str, transform=None):
         self.cfg = cfg
         self.data = data
         self.phase = phase
@@ -59,7 +59,7 @@ class MultiSpecDataset(torch.utils.data.Dataset):
 
 
 class MultiSpecExtDataset(MultiSpecDataset):
-    def __init__(self, cfg, data: pd.DataFrame, phase: str, transform=None):
+    def __init__(self, cfg, data: "pd.DataFrame", phase: str, transform=None):
         super().__init__(cfg, data, phase, transform)
         self.dataset_map = get_dataset_map(cfg)
 

--- a/utmosv2/dataset/ssl.py
+++ b/utmosv2/dataset/ssl.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class SSLDataset(torch.utils.data.Dataset):
-    def __init__(self, cfg, data: pd.DataFrame, phase: str):
+    def __init__(self, cfg, data: "pd.DataFrame", phase: str):
         self.cfg = cfg
         self.data = data
         self.phase = phase
@@ -38,7 +38,7 @@ class SSLDataset(torch.utils.data.Dataset):
 
 
 class SSLExtDataset(SSLDataset):
-    def __init__(self, cfg, data: pd.DataFrame, phase: str):
+    def __init__(self, cfg, data: "pd.DataFrame", phase: str):
         super().__init__(cfg, data, phase)
         self.dataset_map = get_dataset_map(cfg)
 

--- a/utmosv2/dataset/ssl_multispec.py
+++ b/utmosv2/dataset/ssl_multispec.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class SSLLMultiSpecExtDataset(torch.utils.data.Dataset):
-    def __init__(self, cfg, data: pd.DataFrame, phase: str, transform=None):
+    def __init__(self, cfg, data: "pd.DataFrame", phase: str, transform=None):
         self.data = data
         self.ssl = SSLExtDataset(cfg, data, phase)
         self.multi_spec = MultiSpecDataset(cfg, data, phase, transform)

--- a/utmosv2/runner/_inference.py
+++ b/utmosv2/runner/_inference.py
@@ -18,7 +18,7 @@ def run_inference(
     model: torch.nn.Module,
     test_dataloader: torch.utils.data.DataLoader,
     cycle: int,
-    test_data: pd.DataFrame,
+    test_data: "pd.DataFrame",
     device: torch.device,
 ) -> tuple[np.ndarray, dict[str, float] | None]:
     model.eval()

--- a/utmosv2/runner/_train.py
+++ b/utmosv2/runner/_train.py
@@ -153,7 +153,7 @@ def run_train(
     model: torch.nn.Module,
     train_dataloader: torch.utils.data.DataLoader,
     valid_dataloader: torch.utils.data.DataLoader,
-    valid_data: pd.DataFrame,
+    valid_data: "pd.DataFrame",
     oof_preds: np.ndarray,
     now_fold: int,
     criterion: torch.nn.Module,

--- a/utmosv2/transform/_xymasking.py
+++ b/utmosv2/transform/_xymasking.py
@@ -25,7 +25,7 @@ class XYMasking:
         self.fill_value = fill_value
         self.p = p
 
-    def __call__(self, img: torch.Tensor) -> torch.Tensor:
+    def __call__(self, img: "torch.Tensor") -> "torch.Tensor":
         if np.random.rand() < self.p:
             return img
         _, width, height = img.shape

--- a/utmosv2/utils/_pure/save.py
+++ b/utmosv2/utils/_pure/save.py
@@ -6,7 +6,7 @@ if TYPE_CHECKING:
     import numpy as np
 
 
-def save_oof_preds(cfg, data: pd.DataFrame, oof_preds: np.ndarray, fold: int):
+def save_oof_preds(cfg, data: pd.DataFrame, oof_preds: "np.ndarray", fold: int):
     oof_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "oof_preds": oof_preds})
     oof_df.to_csv(
         cfg.save_path / f"fold{fold}_s{cfg.split.seed}_oof_preds.csv", index=False

--- a/utmosv2/utils/_pure/split.py
+++ b/utmosv2/utils/_pure/split.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 
 def split_data(
-    cfg, data: pd.DataFrame
+    cfg, data: "pd.DataFrame"
 ) -> Generator[tuple[np.ndarray, np.ndarray], None, None]:
     if cfg.print_config:
         print(f"Using split: {cfg.split.type}")

--- a/utmosv2/utils/_task_dependents/log.py
+++ b/utmosv2/utils/_task_dependents/log.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-def show_inference_data(data: pd.DataFrame):
+def show_inference_data(data: "pd.DataFrame"):
     print(
         data[[c for c in data.columns if c != "mos"]]
         .rename(columns={"dataset": "predict_dataset"})

--- a/utmosv2/utils/_task_dependents/metrics.py
+++ b/utmosv2/utils/_task_dependents/metrics.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-def calc_metrics(data: pd.DataFrame, preds: np.ndarray) -> dict[str, float]:
+def calc_metrics(data: "pd.DataFrame", preds: np.ndarray) -> dict[str, float]:
     data = data.copy()
     data["preds"] = preds
     data_sys = data.groupby("sys_id", as_index=False)[["mos", "preds"]].mean()


### PR DESCRIPTION
## 🎯 Motivation

Prevent runtime errors caused by unresolved type annotations.

## 📝 Description of Changes

- Wrapped type annotations in quotes for modules imported under TYPE_CHECKING to prevent runtime errors.

## 🔖 Additional Notes