### PR TITLE
Improve documentation for wandb API key setup and PEP 660 support

### DIFF
--- a/docs/reproduction.md
+++ b/docs/reproduction.md
@@ -23,6 +23,7 @@ We used a 40GB A100 GPU for training and inference.
 To install the dependencies required for training, run the following command:
 
 ```bash
+pip install --upgrade pip  # enable PEP 660 support
 pip install -e .[train]
 ```
 

--- a/docs/training.md
+++ b/docs/training.md
@@ -20,6 +20,7 @@ To train UTMOSv2 following the methods described in the paper or used in the com
 To install the dependencies required for training, run the following command:
 
 ```bash
+pip install --upgrade pip  # enable PEP 660 support
 pip install -e .[train]
 ```
 
@@ -97,7 +98,7 @@ The `--weight` option can specify either the configuration file name or the path
   </a>
 </h2>
 
-To use Weights & Biases (wandb) for experiment tracking, specify the `--wandb` option. You will also need to set the `WANDB_API_KEY` in your `.env` file or environment variables.
+To use Weights & Biases (wandb) for experiment tracking, specify the `--wandb` option. You will also need to set the `WANDB_API_KEY` in your `.env` file or environment variables, or follow the prompt during execution to input your API key directly in the command line.
 
 ```bash
 python train.py --config spec_only --data_config data_config.json --wandb


### PR DESCRIPTION
## 🎯 Motivation

Update document to make more user-friendly.

## 📝 Description of Changes

- Explain that users can not only set the `WANDB_API_KEY` in the `.env` file but also input the API key directly via the command line.
- Add instructions to enable PEP 660 support for training installation


## 🔖 Additional Notes