### PR TITLE
Configure package discovery in `setuptools` to ensure correct installation via pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ requires-python = ">=3.9"
 checking = ["ruff", "mypy", "types-setuptools", "types-tqdm"]
 train = ["scikit-learn>=1.3.2", "wandb>=0.17.0", "python-dotenv>=1.0.1"]
 
-[tool.setuptools]
-packages = ["utmosv2"]
+[tool.setuptools.packages.find]
+include = ["utmosv2*"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,4 @@ include = ["utmosv2*"]
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true
+exclude = ["^build/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ checking = ["ruff", "mypy", "types-setuptools", "types-tqdm"]
 train = ["scikit-learn>=1.3.2", "wandb>=0.17.0", "python-dotenv>=1.0.1"]
 
 [tool.setuptools]
-py-modules = []
+packages = ["utmosv2"]
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
## 🎯 Motivation

To ensure that the project can be correctly installed via `pip install git+https://github.com/sarulab-speech/UTMOSv2.git` or some other methods.

## 📝 Description of Changes

- Configured package discovery in `setuptools` to support proper installation.
- Excluded the `build` directory from `mypy` checks to prevent failures in CI after making the above changes.


## 🔖 Additional Notes