### PR TITLE
Refactor dataset handling with `BaseDataset` class and add `transform` type annotations

### DIFF
--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -1,0 +1,29 @@
+import abc
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+class BaseDataset(torch.utils.data.Dataset, abc.ABC):
+    def __init__(
+        self,
+        cfg,
+        data: "pd.DataFrame",
+        phase: str,
+        transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    ):
+        self.cfg = cfg
+        self.data = data
+        self.phase = phase
+        self.transform = transform
+
+    def __len__(self):
+        return len(self.data)
+
+    @abc.abstractmethod
+    def __getitem__(self, idx):
+        pass

--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -1,9 +1,11 @@
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import librosa
 import numpy as np
 import torch
 
+from utmosv2.dataset._base import BaseDataset
 from utmosv2.dataset._utils import (
     extend_audio,
     get_dataset_map,
@@ -15,16 +17,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-class MultiSpecDataset(torch.utils.data.Dataset):
-    def __init__(self, cfg, data: "pd.DataFrame", phase: str, transform=None):
-        self.cfg = cfg
-        self.data = data
-        self.phase = phase
-        self.transform = transform
-
-    def __len__(self):
-        return len(self.data)
-
+class MultiSpecDataset(BaseDataset):
     def __getitem__(self, idx):
         row = self.data.iloc[idx]
         file = row["file_path"]
@@ -59,7 +52,13 @@ class MultiSpecDataset(torch.utils.data.Dataset):
 
 
 class MultiSpecExtDataset(MultiSpecDataset):
-    def __init__(self, cfg, data: "pd.DataFrame", phase: str, transform=None):
+    def __init__(
+        self,
+        cfg,
+        data: "pd.DataFrame",
+        phase: str,
+        transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    ):
         super().__init__(cfg, data, phase, transform)
         self.dataset_map = get_dataset_map(cfg)
 

--- a/utmosv2/dataset/ssl.py
+++ b/utmosv2/dataset/ssl.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
 
+from utmosv2.dataset._base import BaseDataset
 from utmosv2.dataset._utils import (
     extend_audio,
     get_dataset_map,
@@ -14,15 +17,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-class SSLDataset(torch.utils.data.Dataset):
-    def __init__(self, cfg, data: "pd.DataFrame", phase: str):
-        self.cfg = cfg
-        self.data = data
-        self.phase = phase
-
-    def __len__(self):
-        return len(self.data)
-
+class SSLDataset(BaseDataset):
     def __getitem__(self, idx):
         row = self.data.iloc[idx]
         file = row["file_path"]

--- a/utmosv2/dataset/ssl_multispec.py
+++ b/utmosv2/dataset/ssl_multispec.py
@@ -1,16 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 import torch
 
 from utmosv2.dataset import MultiSpecDataset, SSLExtDataset
+from utmosv2.dataset._base import BaseDataset
 
 if TYPE_CHECKING:
     import pandas as pd
 
 
-class SSLLMultiSpecExtDataset(torch.utils.data.Dataset):
-    def __init__(self, cfg, data: "pd.DataFrame", phase: str, transform=None):
-        self.data = data
+class SSLLMultiSpecExtDataset(BaseDataset):
+    def __init__(
+        self,
+        cfg,
+        data: "pd.DataFrame",
+        phase: str,
+        transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    ):
+        super().__init__(cfg, data, phase, transform)
         self.ssl = SSLExtDataset(cfg, data, phase)
         self.multi_spec = MultiSpecDataset(cfg, data, phase, transform)
 


### PR DESCRIPTION
## 🎯 Motivation

To provide a reusable base class for datasets that enforces a consistent interface for custom datasets using `torch.utils.data.Dataset`.

## 📝 Description of Changes

- Implement `BaseDataset` class that inherits from `torch.utils.data.Dataset`.
- Added type annotations for `transform`.

## 🔖 Additional Notes