### PR TITLE
Fix naming convention inconsistency in optional dependencies in `pyproject.toml`

### DIFF
--- a/.github/workflows/mypy_check.yml
+++ b/.github/workflows/mypy_check.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install -U pip
-          pip install --progress-bar off -U .[checking]
+          pip install --progress-bar off -U .[check]
 
       - name: Mypy Check
         run: mypy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 
 [project.optional-dependencies]
-checking = ["ruff", "mypy", "types-setuptools", "types-tqdm"]
+check = ["ruff", "mypy", "types-setuptools", "types-tqdm"]
 train = ["scikit-learn>=1.3.2", "wandb>=0.17.0", "python-dotenv>=1.0.1"]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
## 🎯 Motivation

To ensure consistency in the naming conventions for optional dependencies in `pyproject.toml`.


## 📝 Description of Changes

- Renamed the optional dependency group `checking` to `check` to match the naming convention used with `train`.


## 🔖 Additional Notes