### PR TITLE
Update instructions for optional dependencies

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -10,6 +10,20 @@
 
 Please refer to [this section](https://github.com/sarulab-speech/UTMOSv2?tab=readme-ov-file#---quick-prediction--------) for basic inference methods.
 
+If you want to use the `inference.py` scripts, rather than using the `utmosv2` library, please install some additional dependencies:
+
+```bash
+pip install --upgrade pip  # enable PEP 660 support
+pip install -e .[optional]
+```
+
+> [!NOTE]
+> If you are using zsh, make sure to escape the square brackets like this:
+>
+> ```zsh
+> pip install -e '.[optional]'
+> ```
+
 <h2 align="center">
   <div>📌 Data-domain ID for the MOS Prediction 📌</div>
   <a href="https://github.com/sarulab-speech/UTMOSv2/blob/main/docs/inference.md#---data-domain-id-for-the-mos-prediction---------">

--- a/docs/reproduction.md
+++ b/docs/reproduction.md
@@ -24,13 +24,14 @@ To install the dependencies required for training, run the following command:
 
 ```bash
 pip install --upgrade pip  # enable PEP 660 support
-pip install -e .[train]
+pip install -e .[train,optional]
 ```
 
 > [!NOTE]
 > If you are using zsh, make sure to escape the square brackets like this:
+>
 > ```zsh
-> pip install -e '.[train]'
+> pip install -e '.[train,optional]'
 > ```
 
 <h2 align="left">

--- a/docs/training.md
+++ b/docs/training.md
@@ -21,13 +21,14 @@ To install the dependencies required for training, run the following command:
 
 ```bash
 pip install --upgrade pip  # enable PEP 660 support
-pip install -e .[train]
+pip install -e .[train,optional]
 ```
 
 > [!NOTE]
 > If you are using zsh, make sure to escape the square brackets like this:
+>
 > ```zsh
-> pip install -e '.[train]'
+> pip install -e '.[train,optional]'
 > ```
 
 <h2 align="center">
@@ -68,7 +69,7 @@ sys7ab3c-utt1417b69,4.0
 
 The file extension `.wav` is optional and can be included or omitted. The common files between those in the dir and those specified in the mos_list will be used.
 
-Specify the name, dir, and mos_list set for each dataset-domain ID you want to train. 
+Specify the name, dir, and mos_list set for each dataset-domain ID you want to train.
 
 Save this JSON file with an appropriate name, for example, `data_config.json` and run the following command:
 


### PR DESCRIPTION
## 🎯 Motivation

Since `pandas` is no longer installed as a dependencies (#26), the instruction in documents should be updated.


## 📝 Description of Changes

- Updated instructions for optional dependencies.

## 🔖 Additional Notes