### PR TITLE
Fix name order in citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,14 +7,14 @@ url: "https://github.com/sarulab-speech/UTMOSv2"
 preferred-citation:
   type: conference-paper
   authors:
-    - family-names: "Kaito"
-      given-names: "Baba"
-    - family-names: "Wataru"
-      given-names: "Nakata"
-    - family-names: "Yuki"
-      given-names: "Saito"
-    - family-names: "Hiroshi"
-      given-names: "Saruwatari"
+    - family-names: "Baba"
+      given-names: "Kaito"
+    - family-names: "Nakata"
+      given-names: "Wataru"
+    - family-names: "Saito"
+      given-names: "Yuki"
+    - family-names: "Saruwatari"
+      given-names: "Hiroshi"
   collection-title: "IEEE Spoken Language Technology Workshop (SLT)"
   title: "The t05 system for the VoiceMOS Challenge 2024: Transfer learning from deep image classifier to naturalness MOS prediction of high-quality synthetic speech"
   year: 2024

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ If you find UTMOSv2 useful in your research, please cite the following paper:
 ```bibtex
 @inproceedings{baba2024utmosv2,
   title     = {The T05 System for The {V}oice{MOS} {C}hallenge 2024: Transfer Learning from Deep Image Classifier to Naturalness {MOS} Prediction of High-Quality Synthetic Speech},
-  author    = {Kaito, Baba and Wataru, Nakata and Yuki, Saito and Hiroshi, Saruwatari},
+  author    = {Baba, Kaito and Nakata, Wataru and Saito, Yuki and Saruwatari, Hiroshi},
   booktitle = {IEEE Spoken Language Technology Workshop (SLT)},
   year      = {2024},
 }


### PR DESCRIPTION
## 🎯 Motivation

In BibTeX, names are written in the order of family name followed by given name, not given name followed by family name, so the order is different.

## 📝 Description of Changes

This PR contains the following changes:
- Fix BibTeX information in `README.md`
- Fix `CITATION.cff`

## 🔖 Additional Notes