### PR TITLE
Add config type

### DIFF
--- a/utmosv2/_settings/_config.py
+++ b/utmosv2/_settings/_config.py
@@ -8,46 +8,46 @@ Config: TypeAlias = SimpleNamespace | ModuleType
 
 
 def configure_args(cfg: Config, args):
-    cfg.fold = args.fold
-    cfg.split.seed = args.seed
-    cfg.config_name = args.config
-    cfg.input_dir = args.input_dir and Path(args.input_dir)
-    cfg.num_workers = args.num_workers
-    cfg.weight = args.weight
-    cfg.save_path = Path("models") / cfg.config_name
-    cfg.wandb = args.wandb
-    cfg.reproduce = args.reproduce
-    cfg.data_config = args.data_config
-    cfg.phase = "train"
+    cfg.fold = args.fold  # type: ignore
+    cfg.split.seed = args.seed  # type: ignore
+    cfg.config_name = args.config  # type: ignore
+    cfg.input_dir = args.input_dir and Path(args.input_dir)  # type: ignore
+    cfg.num_workers = args.num_workers  # type: ignore
+    cfg.weight = args.weight  # type: ignore
+    cfg.save_path = Path("models") / cfg.config_name  # type: ignore
+    cfg.wandb = args.wandb  # type: ignore
+    cfg.reproduce = args.reproduce  # type: ignore
+    cfg.data_config = args.data_config  # type: ignore
+    cfg.phase = "train"  # type: ignore
 
 
 def configure_inference_args(cfg: Config, args):
-    cfg.inference.fold = args.fold
-    cfg.split.seed = args.seed
-    cfg.config_name = args.config
-    cfg.input_dir = args.input_dir and Path(args.input_dir)
-    cfg.input_path = args.input_path and Path(args.input_path)
-    cfg.num_workers = args.num_workers
-    cfg.weight = args.weight
+    cfg.inference.fold = args.fold  # type: ignore
+    cfg.split.seed = args.seed  # type: ignore
+    cfg.config_name = args.config  # type: ignore
+    cfg.input_dir = args.input_dir and Path(args.input_dir)  # type: ignore
+    cfg.input_path = args.input_path and Path(args.input_path)  # type: ignore
+    cfg.num_workers = args.num_workers  # type: ignore
+    cfg.weight = args.weight  # type: ignore
     if not cfg.weight:
-        cfg.weight = cfg.config_name
-    cfg.inference.val_list_path = args.val_list_path and Path(args.val_list_path)
-    cfg.save_path = Path("models") / cfg.config_name
-    cfg.predict_dataset = args.predict_dataset
-    cfg.final = args.final
-    cfg.inference.num_tta = args.num_repetitions
-    cfg.reproduce = args.reproduce
-    cfg.out_path = args.out_path and Path(args.out_path)
-    cfg.data_config = None
-    cfg.phase = "inference"
+        cfg.weight = cfg.config_name  # type: ignore
+    cfg.inference.val_list_path = args.val_list_path and Path(args.val_list_path)  # type: ignore
+    cfg.save_path = Path("models") / cfg.config_name  # type: ignore
+    cfg.predict_dataset = args.predict_dataset  # type: ignore
+    cfg.final = args.final  # type: ignore
+    cfg.inference.num_tta = args.num_repetitions  # type: ignore
+    cfg.reproduce = args.reproduce  # type: ignore
+    cfg.out_path = args.out_path and Path(args.out_path)  # type: ignore
+    cfg.data_config = None  # type: ignore
+    cfg.phase = "inference"  # type: ignore
 
 
 def configure_defaults(cfg: Config):
     if cfg.id_name is None:
-        cfg.id_name = "utt_id"
+        cfg.id_name = "utt_id"  # type: ignore
 
 
 def configure_execution(cfg: Config):
-    cfg.data_config = None
-    cfg.phase = "prediction"
-    cfg.print_config = False
+    cfg.data_config = None  # type: ignore
+    cfg.phase = "prediction"  # type: ignore
+    cfg.print_config = False  # type: ignore

--- a/utmosv2/_settings/_config.py
+++ b/utmosv2/_settings/_config.py
@@ -1,7 +1,13 @@
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import TypeAlias
+
+# NOTE: Python 3.12 introduces the type statement, so once Python 3.11 is dropped,
+# it should be updated to use that instead.
+Config: TypeAlias = SimpleNamespace | ModuleType
 
 
-def configure_args(cfg, args):
+def configure_args(cfg: Config, args):
     cfg.fold = args.fold
     cfg.split.seed = args.seed
     cfg.config_name = args.config
@@ -15,7 +21,7 @@ def configure_args(cfg, args):
     cfg.phase = "train"
 
 
-def configure_inference_args(cfg, args):
+def configure_inference_args(cfg: Config, args):
     cfg.inference.fold = args.fold
     cfg.split.seed = args.seed
     cfg.config_name = args.config
@@ -36,12 +42,12 @@ def configure_inference_args(cfg, args):
     cfg.phase = "inference"
 
 
-def configure_defaults(cfg):
+def configure_defaults(cfg: Config):
     if cfg.id_name is None:
         cfg.id_name = "utt_id"
 
 
-def configure_execution(cfg):
+def configure_execution(cfg: Config):
     cfg.data_config = None
     cfg.phase = "prediction"
     cfg.print_config = False

--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from utmosv2._settings._config import Config
+
 if TYPE_CHECKING:
     import pandas as pd
 
@@ -15,7 +17,7 @@ if TYPE_CHECKING:
 class BaseDataset(torch.utils.data.Dataset, abc.ABC):
     def __init__(
         self,
-        cfg,
+        cfg : Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
         transform: Callable[[torch.Tensor], torch.Tensor] | None = None,

--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 class BaseDataset(torch.utils.data.Dataset, abc.ABC):
     def __init__(
         self,
-        cfg : Config,
+        cfg: Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
         transform: Callable[[torch.Tensor], torch.Tensor] | None = None,

--- a/utmosv2/dataset/_utils.py
+++ b/utmosv2/dataset/_utils.py
@@ -4,8 +4,10 @@ from pathlib import Path
 import librosa
 import numpy as np
 
+from utmosv2._settings._config import Config
 
-def load_audio(cfg, file: Path) -> np.ndarray:
+
+def load_audio(cfg: Config, file: Path) -> np.ndarray:
     if file.suffix in [".wav", ".flac"]:
         y, sr = librosa.load(file, sr=None)
         y = librosa.resample(y, orig_sr=sr, target_sr=cfg.sr)
@@ -14,7 +16,7 @@ def load_audio(cfg, file: Path) -> np.ndarray:
     return y
 
 
-def extend_audio(cfg, y: np.ndarray, length: int, type: str) -> np.ndarray:
+def extend_audio(cfg: Config, y: np.ndarray, length: int, type: str) -> np.ndarray:
     if y.shape[0] > length:
         return y
     elif type == "tile":
@@ -30,7 +32,7 @@ def select_random_start(y: np.ndarray, length: int) -> np.ndarray:
     return y[start : start + length]
 
 
-def get_dataset_map(cfg):
+def get_dataset_map(cfg: Config):
     if cfg.data_config:
         with open(cfg.data_config, "r") as f:
             datasets = json.load(f)

--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -9,8 +9,12 @@ import torch
 
 from utmosv2._settings._config import Config
 from utmosv2.dataset._base import BaseDataset
-from utmosv2.dataset._utils import (extend_audio, get_dataset_map, load_audio,
-                                    select_random_start)
+from utmosv2.dataset._utils import (
+    extend_audio,
+    get_dataset_map,
+    load_audio,
+    select_random_start,
+)
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -7,13 +7,10 @@ import librosa
 import numpy as np
 import torch
 
+from utmosv2._settings._config import Config
 from utmosv2.dataset._base import BaseDataset
-from utmosv2.dataset._utils import (
-    extend_audio,
-    get_dataset_map,
-    load_audio,
-    select_random_start,
-)
+from utmosv2.dataset._utils import (extend_audio, get_dataset_map, load_audio,
+                                    select_random_start)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -93,7 +90,7 @@ class MultiSpecExtDataset(MultiSpecDataset):
 
     def __init__(
         self,
-        cfg,
+        cfg: Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
         transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
@@ -122,7 +119,7 @@ class MultiSpecExtDataset(MultiSpecDataset):
         return spec, d, target
 
 
-def _make_spctrogram(cfg, spec_cfg, y: np.ndarray) -> np.ndarray:
+def _make_spctrogram(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
     if spec_cfg.mode == "melspec":
         return _make_melspec(cfg, spec_cfg, y)
     elif spec_cfg.mode == "stft":
@@ -131,7 +128,7 @@ def _make_spctrogram(cfg, spec_cfg, y: np.ndarray) -> np.ndarray:
         raise NotImplementedError
 
 
-def _make_melspec(cfg, spec_cfg, y: np.ndarray) -> np.ndarray:
+def _make_melspec(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
     spec = librosa.feature.melspectrogram(
         y=y,
         sr=cfg.sr,
@@ -146,7 +143,7 @@ def _make_melspec(cfg, spec_cfg, y: np.ndarray) -> np.ndarray:
     return spec
 
 
-def _make_stft(cfg, spec_cfg, y: np.ndarray) -> np.ndarray:
+def _make_stft(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
     spec = librosa.stft(y=y, n_fft=spec_cfg.n_fft, hop_length=spec_cfg.hop_length)
     spec = np.abs(spec)
     spec = librosa.amplitude_to_db(spec)

--- a/utmosv2/dataset/ssl_multispec.py
+++ b/utmosv2/dataset/ssl_multispec.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
+from utmosv2._settings._config import Config
 from utmosv2.dataset import MultiSpecDataset, SSLExtDataset
 from utmosv2.dataset._base import BaseDataset
 
@@ -33,7 +34,7 @@ class SSLLMultiSpecExtDataset(BaseDataset):
 
     def __init__(
         self,
-        cfg,
+        cfg: Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
         transform: Callable[[torch.Tensor], torch.Tensor] | None = None,

--- a/utmosv2/model/multi_spec.py
+++ b/utmosv2/model/multi_spec.py
@@ -2,6 +2,7 @@ import timm
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from typing import cast
 
 from utmosv2._settings._config import Config
 from utmosv2.dataset._utils import get_dataset_num
@@ -39,14 +40,14 @@ class MultiSpecModelV2(nn.Module):
         )
 
         self.pooling = timm.layers.SelectAdaptivePool2d(
-            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1,
+            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1, # type: ignore
             pool_type=self.cfg.model.multi_spec.pool_type,
             flatten=False,
         )
 
         if self.cfg.model.multi_spec.atten:
             self.attn = nn.MultiheadAttention(
-                embed_dim=self.backbones[0].num_features
+                embed_dim=cast(int, self.backbones[0].num_features)
                 * (2 if self.cfg.model.multi_spec.pool_type == "catavgmax" else 1),
                 num_heads=8,
                 dropout=0.2,
@@ -54,12 +55,12 @@ class MultiSpecModelV2(nn.Module):
             )
 
         fc_in_features = (
-            self.backbones[0].num_features
+            cast(int, self.backbones[0].num_features)
             * (2 if self.cfg.model.multi_spec.pool_type == "catavgmax" else 1)
             * (2 if self.cfg.model.multi_spec.atten else 1)
         )
 
-        self.fc = nn.Linear(fc_in_features, cfg.model.multi_spec.num_classes)
+        self.fc : nn.Linear | nn.Identity = nn.Linear(fc_in_features, cfg.model.multi_spec.num_classes)
 
         # if cfg.print_config:
         #     print(f"| backbone model: {cfg.model.multi_spec.backbone}")
@@ -144,14 +145,14 @@ class MultiSpecExtModel(nn.Module):
         )
 
         self.pooling = timm.layers.SelectAdaptivePool2d(
-            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1,
+            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1, # type: ignore
             pool_type=self.cfg.model.multi_spec.pool_type,
             flatten=False,
         )
 
         if self.cfg.model.multi_spec.atten:
             self.attn = nn.MultiheadAttention(
-                embed_dim=self.backbones[0].num_features
+                embed_dim=cast(int, self.backbones[0].num_features)
                 * (2 if self.cfg.model.multi_spec.pool_type == "catavgmax" else 1),
                 num_heads=8,
                 dropout=0.2,
@@ -159,7 +160,7 @@ class MultiSpecExtModel(nn.Module):
             )
 
         fc_in_features = (
-            self.backbones[0].num_features
+            cast(int, self.backbones[0].num_features)
             * (2 if self.cfg.model.multi_spec.pool_type == "catavgmax" else 1)
             * (2 if self.cfg.model.multi_spec.atten else 1)
         )

--- a/utmosv2/model/multi_spec.py
+++ b/utmosv2/model/multi_spec.py
@@ -3,6 +3,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from utmosv2._settings._config import Config
 from utmosv2.dataset._utils import get_dataset_num
 
 
@@ -17,7 +18,7 @@ class MultiSpecModelV2(nn.Module):
             Configuration object containing model and dataset settings.
     """
 
-    def __init__(self, cfg):
+    def __init__(self, cfg: Config):
         super().__init__()
         self.cfg = cfg
         self.backbones = nn.ModuleList(
@@ -122,7 +123,7 @@ class MultiSpecExtModel(nn.Module):
             through backbones, pooling, and fully connected layers.
     """
 
-    def __init__(self, cfg):
+    def __init__(self, cfg: Config):
         super().__init__()
         self.cfg = cfg
         self.backbones = nn.ModuleList(

--- a/utmosv2/model/multi_spec.py
+++ b/utmosv2/model/multi_spec.py
@@ -40,7 +40,7 @@ class MultiSpecModelV2(nn.Module):
         )
 
         self.pooling = timm.layers.SelectAdaptivePool2d(
-            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1, # type: ignore
+            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1,  # type: ignore
             pool_type=self.cfg.model.multi_spec.pool_type,
             flatten=False,
         )
@@ -60,7 +60,9 @@ class MultiSpecModelV2(nn.Module):
             * (2 if self.cfg.model.multi_spec.atten else 1)
         )
 
-        self.fc : nn.Linear | nn.Identity = nn.Linear(fc_in_features, cfg.model.multi_spec.num_classes)
+        self.fc: nn.Linear | nn.Identity = nn.Linear(
+            fc_in_features, cfg.model.multi_spec.num_classes
+        )
 
         # if cfg.print_config:
         #     print(f"| backbone model: {cfg.model.multi_spec.backbone}")
@@ -145,7 +147,7 @@ class MultiSpecExtModel(nn.Module):
         )
 
         self.pooling = timm.layers.SelectAdaptivePool2d(
-            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1, # type: ignore
+            output_size=(None, 1) if self.cfg.model.multi_spec.atten else 1,  # type: ignore
             pool_type=self.cfg.model.multi_spec.pool_type,
             flatten=False,
         )

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -41,7 +41,7 @@ class SSLExtModel(nn.Module):
             Optional name for the SSL encoder. Defaults to the name specified in `cfg.model.ssl.name`.
     """
 
-    def __init__(self, cfg, name: str | None = None):
+    def __init__(self, cfg: Config, name: str | None = None):
         super().__init__()
         self.cfg = cfg
         self.encoder = _SSLEncoder(

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import AutoFeatureExtractor, AutoModel
 
+from utmosv2._settings._config import Config
 from utmosv2.dataset._utils import get_dataset_num
 
 

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -63,7 +63,7 @@ class SSLExtModel(nn.Module):
                 ]
             )
         self.num_dataset = get_dataset_num(cfg)
-        self.fc = nn.Linear(
+        self.fc: nn.Linear | nn.Identity = nn.Linear(
             in_features * 2 + self.num_dataset, cfg.model.ssl.num_classes
         )
 

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from typing import cast
 
 from utmosv2._settings._config import Config
 from utmosv2.dataset._utils import get_dataset_num
@@ -27,15 +28,13 @@ class SSLMultiSpecExtModelV1(nn.Module):
                 param.requires_grad = False
             for param in self.spec_long.parameters():
                 param.requires_grad = False
-        ssl_input = self.ssl.fc.in_features
-        spec_long_input = self.spec_long.fc.in_features
         self.ssl.fc = nn.Identity()
         self.spec_long.fc = nn.Identity()
 
         self.num_dataset = get_dataset_num(cfg)
 
         self.fc = nn.Linear(
-            ssl_input + spec_long_input + self.num_dataset,
+            cast(int, self.ssl.fc.in_features) + cast(int, self.spec_long.fc.in_features) + self.num_dataset,
             cfg.model.ssl_spec.num_classes,
         )
 
@@ -70,15 +69,13 @@ class SSLMultiSpecExtModelV2(nn.Module):
                 param.requires_grad = False
             for param in self.spec_long.parameters():
                 param.requires_grad = False
-        ssl_input = self.ssl.fc.in_features
-        spec_long_input = self.spec_long.fc.in_features
         self.ssl.fc = nn.Identity()
         self.spec_long.fc = nn.Identity()
 
         self.num_dataset = get_dataset_num(cfg)
 
         self.fc = nn.Linear(
-            ssl_input + spec_long_input + self.num_dataset,
+            cast(int, self.ssl.fc.in_features) + cast(int, self.spec_long.fc.in_features) + self.num_dataset,
             cfg.model.ssl_spec.num_classes,
         )
 

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -34,7 +34,9 @@ class SSLMultiSpecExtModelV1(nn.Module):
         self.num_dataset = get_dataset_num(cfg)
 
         self.fc = nn.Linear(
-            cast(int, self.ssl.fc.in_features) + cast(int, self.spec_long.fc.in_features) + self.num_dataset,
+            cast(int, self.ssl.fc.in_features)
+            + cast(int, self.spec_long.fc.in_features)
+            + self.num_dataset,
             cfg.model.ssl_spec.num_classes,
         )
 
@@ -75,7 +77,9 @@ class SSLMultiSpecExtModelV2(nn.Module):
         self.num_dataset = get_dataset_num(cfg)
 
         self.fc = nn.Linear(
-            cast(int, self.ssl.fc.in_features) + cast(int, self.spec_long.fc.in_features) + self.num_dataset,
+            cast(int, self.ssl.fc.in_features)
+            + cast(int, self.spec_long.fc.in_features)
+            + self.num_dataset,
             cfg.model.ssl_spec.num_classes,
         )
 

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -1,12 +1,13 @@
 import torch
 import torch.nn as nn
 
+from utmosv2._settings._config import Config
 from utmosv2.dataset._utils import get_dataset_num
 from utmosv2.model import MultiSpecExtModel, MultiSpecModelV2, SSLExtModel
 
 
 class SSLMultiSpecExtModelV1(nn.Module):
-    def __init__(self, cfg):
+    def __init__(self, cfg: Config):
         super().__init__()
         self.cfg = cfg
         self.ssl = SSLExtModel(cfg)

--- a/utmosv2/preprocess/_preprocess.py
+++ b/utmosv2/preprocess/_preprocess.py
@@ -7,6 +7,7 @@ import numpy as np
 from tqdm import tqdm
 
 from utmosv2._import import _LazyImport
+from utmosv2._settings._config import Config
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -14,7 +15,7 @@ else:
     pd = _LazyImport("pandas")
 
 
-def _clip_audio(cfg, data: "pd.DataFrame", data_name: str = "bvcc"):
+def _clip_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
     (cfg.preprocess.save_path / data_name).mkdir(parents=True, exist_ok=True)
     for file in tqdm(data["file_path"].values, desc="Clipping audio files"):
         y, _ = librosa.load(file, sr=None)
@@ -27,7 +28,7 @@ def _clip_audio(cfg, data: "pd.DataFrame", data_name: str = "bvcc"):
         )
 
 
-def _select_audio(cfg, data: "pd.DataFrame", data_name: str = "bvcc"):
+def _select_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
     if cfg.preprocess.min_seconds is None:
         return data
     select_file_name = f"min_seconds={cfg.preprocess.min_seconds}.txt"
@@ -54,7 +55,7 @@ def _select_audio(cfg, data: "pd.DataFrame", data_name: str = "bvcc"):
 
 
 def _clip_and_select_audio(
-    cfg, data: "pd.DataFrame", data_name: str = "bvcc"
+    cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"
 ) -> "pd.DataFrame":
     if not (cfg.preprocess.save_path / data_name).exists():
         _clip_audio(cfg, data)
@@ -64,7 +65,7 @@ def _clip_and_select_audio(
     return data
 
 
-def _change_file_path(cfg, data: "pd.DataFrame", data_name: str = "bvcc"):
+def _change_file_path(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
     data.loc[:, "file_path"] = data.loc[:, "file_path"].apply(
         lambda x: cfg.preprocess.save_path
         / data_name
@@ -72,7 +73,7 @@ def _change_file_path(cfg, data: "pd.DataFrame", data_name: str = "bvcc"):
     )
 
 
-def _add_metadata(cfg, data: "pd.DataFrame"):
+def _add_metadata(cfg: Config, data: "pd.DataFrame"):
     metadata = []
     for t in ["TRAINSET", "DEVSET", "TESTSET"]:
         meta = pd.read_csv(cfg.input_dir / f"sets/{t}")
@@ -93,7 +94,7 @@ def add_sys_mean(data: "pd.DataFrame"):
     data["sys_mos"] = dt["sys_mos"]
 
 
-def preprocess(cfg, data: "pd.DataFrame") -> "pd.DataFrame":
+def preprocess(cfg: Config, data: "pd.DataFrame") -> "pd.DataFrame":
     data = _clip_and_select_audio(cfg, data)
     _add_metadata(cfg, data)
     add_sys_mean(data)
@@ -111,7 +112,7 @@ def preprocess(cfg, data: "pd.DataFrame") -> "pd.DataFrame":
     return data
 
 
-def preprocess_test(cfg, data: "pd.DataFrame") -> "pd.DataFrame":
+def preprocess_test(cfg: Config, data: "pd.DataFrame") -> "pd.DataFrame":
     _change_file_path(cfg, data)
     _add_metadata(cfg, data)
     add_sys_mean(data)
@@ -119,7 +120,7 @@ def preprocess_test(cfg, data: "pd.DataFrame") -> "pd.DataFrame":
     return data
 
 
-def _get_external_data(cfg, data: "pd.DataFrame") -> "pd.DataFrame":
+def _get_external_data(cfg: Config, data: "pd.DataFrame") -> "pd.DataFrame":
     exdata = []
     if cfg.external_data == "all" or "sarulab" in cfg.external_data:
         ysdata = pd.read_csv(

--- a/utmosv2/runner/_inference.py
+++ b/utmosv2/runner/_inference.py
@@ -7,6 +7,7 @@ import torch
 from torch.cuda.amp import autocast
 from tqdm import tqdm
 
+from utmosv2._settings._config import Config
 from utmosv2.utils import calc_metrics, print_metrics
 
 if TYPE_CHECKING:
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def run_inference(
-    cfg,
+    cfg : Config,
     model: torch.nn.Module,
     test_dataloader: torch.utils.data.DataLoader,
     cycle: int,

--- a/utmosv2/runner/_inference.py
+++ b/utmosv2/runner/_inference.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def run_inference(
-    cfg : Config,
+    cfg: Config,
     model: torch.nn.Module,
     test_dataloader: torch.utils.data.DataLoader,
     cycle: int,

--- a/utmosv2/runner/_train.py
+++ b/utmosv2/runner/_train.py
@@ -11,18 +11,18 @@ from torch.cuda.amp import GradScaler, autocast
 from tqdm import tqdm
 
 from utmosv2._import import _LazyImport
+from utmosv2._settings._config import Config
 from utmosv2.utils import calc_metrics, print_metrics
 
 if TYPE_CHECKING:
     import pandas as pd
-
     import wandb
 else:
     wandb = _LazyImport("wandb")
 
 
 def train_1epoch(
-    cfg,
+    cfg: Config,
     model: torch.nn.Module,
     train_dataloader: torch.utils.data.DataLoader,
     criterion: torch.nn.Module,
@@ -118,7 +118,7 @@ def train_1epoch(
 
 
 def validate_1epoch(
-    cfg,
+    cfg: Config,
     model: torch.nn.Module,
     valid_dataloader: torch.utils.data.DataLoader,
     criterion: torch.nn.Module,
@@ -200,7 +200,7 @@ def validate_1epoch(
 
 
 def run_train(
-    cfg,
+    cfg: Config,
     model: torch.nn.Module,
     train_dataloader: torch.utils.data.DataLoader,
     valid_dataloader: torch.utils.data.DataLoader,

--- a/utmosv2/utils/_pure/initializers.py
+++ b/utmosv2/utils/_pure/initializers.py
@@ -4,11 +4,12 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 
+from utmosv2._settings._config import Config
 from utmosv2.loss import CombinedLoss, PairwizeDiffLoss
 
 
 def get_dataloader(
-    cfg, dataset: torch.utils.data.Dataset, phase: str
+    cfg: Config, dataset: torch.utils.data.Dataset, phase: str
 ) -> torch.utils.data.DataLoader:
     """
     Return a DataLoader for the specified dataset and phase.
@@ -55,7 +56,7 @@ def get_dataloader(
         raise ValueError(f"Phase must be one of [train, valid, test], but got {phase}")
 
 
-def _get_unit_loss(loss_cfg) -> nn.Module:
+def _get_unit_loss(loss_cfg: Config) -> nn.Module:
     if loss_cfg.name == "pairwize_diff":
         return PairwizeDiffLoss(loss_cfg.margin, loss_cfg.norm)
     elif loss_cfg.name == "mse":
@@ -64,7 +65,7 @@ def _get_unit_loss(loss_cfg) -> nn.Module:
         raise NotImplementedError
 
 
-def _get_combined_loss(cfg) -> nn.Module:
+def _get_combined_loss(cfg: Config) -> nn.Module:
     if cfg.print_config:
         print(
             "Using losses: "
@@ -74,7 +75,7 @@ def _get_combined_loss(cfg) -> nn.Module:
     return CombinedLoss(weighted_losses)
 
 
-def get_loss(cfg) -> nn.Module:
+def get_loss(cfg: Config) -> nn.Module:
     """
     Return the appropriate loss function based on the configuration.
 
@@ -93,7 +94,7 @@ def get_loss(cfg) -> nn.Module:
         return _get_unit_loss(cfg.loss)
 
 
-def get_optimizer(cfg, model: nn.Module) -> optim.Optimizer:
+def get_optimizer(cfg: Config, model: nn.Module) -> optim.Optimizer:
     """
     Return the optimizer based on the configuration settings.
 
@@ -131,7 +132,7 @@ def get_optimizer(cfg, model: nn.Module) -> optim.Optimizer:
 
 
 def get_scheduler(
-    cfg, optimizer: optim.Optimizer, n_iterations: int
+    cfg: Config, optimizer: optim.Optimizer, n_iterations: int
 ) -> optim.lr_scheduler.LRScheduler:
     """
     Return the learning rate scheduler based on the configuration settings.

--- a/utmosv2/utils/_pure/save.py
+++ b/utmosv2/utils/_pure/save.py
@@ -10,7 +10,9 @@ else:
     pd = _LazyImport("pandas")
 
 
-def save_oof_preds(cfg: Config, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int):
+def save_oof_preds(
+    cfg: Config, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int
+):
     """
     Save out-of-fold (OOF) predictions to a CSV file.
 

--- a/utmosv2/utils/_pure/save.py
+++ b/utmosv2/utils/_pure/save.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from utmosv2._import import _LazyImport
+from utmosv2._settings._config import Config
 
 if TYPE_CHECKING:
     import numpy as np
@@ -9,7 +10,7 @@ else:
     pd = _LazyImport("pandas")
 
 
-def save_oof_preds(cfg, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int):
+def save_oof_preds(cfg: Config, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int):
     """
     Save out-of-fold (OOF) predictions to a CSV file.
 

--- a/utmosv2/utils/_pure/split.py
+++ b/utmosv2/utils/_pure/split.py
@@ -10,8 +10,12 @@ from utmosv2._settings._config import Config
 
 if TYPE_CHECKING:
     import pandas as pd
-    from sklearn.model_selection import (GroupKFold, KFold,
-                                         StratifiedGroupKFold, StratifiedKFold)
+    from sklearn.model_selection import (
+        GroupKFold,
+        KFold,
+        StratifiedGroupKFold,
+        StratifiedKFold,
+    )
 else:
     _model_selection = _LazyImport("sklearn.model_selection")
     GroupKFold = _model_selection.GroupKFold

--- a/utmosv2/utils/_pure/split.py
+++ b/utmosv2/utils/_pure/split.py
@@ -6,15 +6,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from utmosv2._import import _LazyImport
+from utmosv2._settings._config import Config
 
 if TYPE_CHECKING:
     import pandas as pd
-    from sklearn.model_selection import (
-        GroupKFold,
-        KFold,
-        StratifiedGroupKFold,
-        StratifiedKFold,
-    )
+    from sklearn.model_selection import (GroupKFold, KFold,
+                                         StratifiedGroupKFold, StratifiedKFold)
 else:
     _model_selection = _LazyImport("sklearn.model_selection")
     GroupKFold = _model_selection.GroupKFold
@@ -24,7 +21,7 @@ else:
 
 
 def split_data(
-    cfg, data: "pd.DataFrame"
+    cfg: Config, data: "pd.DataFrame"
 ) -> Generator[tuple[np.ndarray, np.ndarray], None, None]:
     """
     Split the data into training and validation sets based on the specified splitting method in the configuration.

--- a/utmosv2/utils/_task_dependents/initializers.py
+++ b/utmosv2/utils/_task_dependents/initializers.py
@@ -12,20 +12,11 @@ import torch
 import torch.nn as nn
 
 from utmosv2._import import _LazyImport
-from utmosv2.dataset import (
-    MultiSpecDataset,
-    MultiSpecExtDataset,
-    SSLDataset,
-    SSLExtDataset,
-    SSLLMultiSpecExtDataset,
-)
-from utmosv2.model import (
-    MultiSpecExtModel,
-    MultiSpecModelV2,
-    SSLExtModel,
-    SSLMultiSpecExtModelV1,
-    SSLMultiSpecExtModelV2,
-)
+from utmosv2._settings._config import Config
+from utmosv2.dataset import (MultiSpecDataset, MultiSpecExtDataset, SSLDataset,
+                             SSLExtDataset, SSLLMultiSpecExtDataset)
+from utmosv2.model import (MultiSpecExtModel, MultiSpecModelV2, SSLExtModel,
+                           SSLMultiSpecExtModelV1, SSLMultiSpecExtModelV2)
 from utmosv2.preprocess import add_sys_mean, preprocess, preprocess_test
 from utmosv2.utils._constants import _UTMOSV2_CHACHE
 from utmosv2.utils._download import download_pretrained_weights_from_hf
@@ -39,7 +30,7 @@ else:
     pd = _LazyImport("pandas")
 
 
-def get_data(cfg) -> "pd.DataFrame":
+def get_data(cfg: Config) -> "pd.DataFrame":
     train_mos_list = pd.read_csv(cfg.input_dir / "sets/train_mos_list.txt", header=None)
     val_mos_list = pd.read_csv(cfg.input_dir / "sets/val_mos_list.txt", header=None)
     test_mos_list = pd.read_csv(cfg.input_dir / "sets/test_mos_list.txt", header=None)
@@ -50,7 +41,7 @@ def get_data(cfg) -> "pd.DataFrame":
 
 
 def get_dataset(
-    cfg, data: "pd.DataFrame" | list[DatasetSchema], phase: str
+    cfg: Config, data: "pd.DataFrame" | list[DatasetSchema], phase: str
 ) -> torch.utils.data.Dataset:
     if cfg.print_config:
         print(f"Using dataset: {cfg.dataset.name}")
@@ -70,7 +61,7 @@ def get_dataset(
     return res
 
 
-def get_model(cfg, device: torch.device) -> nn.Module:
+def get_model(cfg: Config, device: torch.device) -> nn.Module:
     if cfg.print_config:
         print(f"Using model: {cfg.model.name}")
     model: nn.Module
@@ -115,14 +106,14 @@ def get_metrics() -> dict[str, Callable[[np.ndarray, np.ndarray], float]]:
     }
 
 
-def _get_testdata(cfg, data: "pd.DataFrame") -> "pd.DataFrame":
+def _get_testdata(cfg: Config, data: "pd.DataFrame") -> "pd.DataFrame":
     with open(cfg.inference.val_list_path, "r") as f:
         val_lists = [s.replace("\n", "") + ".wav" for s in f.readlines()]
     test_data = data[data["utt_id"].isin(set(val_lists))]
     return test_data
 
 
-def get_inference_data(cfg) -> "pd.DataFrame":
+def get_inference_data(cfg: Config) -> "pd.DataFrame":
     if cfg.reproduce:
         data = get_data(cfg)
         data = preprocess_test(cfg, data)
@@ -148,7 +139,7 @@ def get_inference_data(cfg) -> "pd.DataFrame":
     return data
 
 
-def get_train_data(cfg) -> "pd.DataFrame":
+def get_train_data(cfg: Config) -> "pd.DataFrame":
     if cfg.reproduce:
         data = get_data(cfg)
         data = preprocess(cfg, data)
@@ -178,12 +169,12 @@ def get_train_data(cfg) -> "pd.DataFrame":
     return data
 
 
-def _get_test_save_name(cfg) -> str:
+def _get_test_save_name(cfg: Config) -> str:
     return f"{cfg.config_name}_[fold{cfg.inference.fold}_tta{cfg.inference.num_tta}_s{cfg.split.seed}]"
 
 
 def save_test_preds(
-    cfg, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
+    cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
 ):
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)

--- a/utmosv2/utils/_task_dependents/initializers.py
+++ b/utmosv2/utils/_task_dependents/initializers.py
@@ -13,10 +13,20 @@ import torch.nn as nn
 
 from utmosv2._import import _LazyImport
 from utmosv2._settings._config import Config
-from utmosv2.dataset import (MultiSpecDataset, MultiSpecExtDataset, SSLDataset,
-                             SSLExtDataset, SSLLMultiSpecExtDataset)
-from utmosv2.model import (MultiSpecExtModel, MultiSpecModelV2, SSLExtModel,
-                           SSLMultiSpecExtModelV1, SSLMultiSpecExtModelV2)
+from utmosv2.dataset import (
+    MultiSpecDataset,
+    MultiSpecExtDataset,
+    SSLDataset,
+    SSLExtDataset,
+    SSLLMultiSpecExtDataset,
+)
+from utmosv2.model import (
+    MultiSpecExtModel,
+    MultiSpecModelV2,
+    SSLExtModel,
+    SSLMultiSpecExtModelV1,
+    SSLMultiSpecExtModelV2,
+)
 from utmosv2.preprocess import add_sys_mean, preprocess, preprocess_test
 from utmosv2.utils._constants import _UTMOSV2_CHACHE
 from utmosv2.utils._download import download_pretrained_weights_from_hf
@@ -174,7 +184,10 @@ def _get_test_save_name(cfg: Config) -> str:
 
 
 def save_test_preds(
-    cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
+    cfg: Config,
+    data: "pd.DataFrame",
+    test_preds: np.ndarray,
+    test_metrics: dict[str, float],
 ):
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)

--- a/utmosv2/utils/_task_dependents/save.py
+++ b/utmosv2/utils/_task_dependents/save.py
@@ -16,7 +16,10 @@ else:
 
 
 def save_test_preds(
-    cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
+    cfg: Config,
+    data: "pd.DataFrame",
+    test_preds: np.ndarray,
+    test_metrics: dict[str, float],
 ):
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)

--- a/utmosv2/utils/_task_dependents/save.py
+++ b/utmosv2/utils/_task_dependents/save.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from utmosv2._import import _LazyImport
+from utmosv2._settings._config import Config
 from utmosv2.utils._task_dependents.initializers import _get_test_save_name
 
 if TYPE_CHECKING:
@@ -15,7 +16,7 @@ else:
 
 
 def save_test_preds(
-    cfg, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
+    cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
 ):
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)
@@ -33,7 +34,7 @@ def save_test_preds(
     print(f"Test predictions are saved to {save_path}")
 
 
-def make_submission_file(cfg, data: "pd.DataFrame", test_preds: np.ndarray):
+def make_submission_file(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray):
     submit = pd.DataFrame({cfg.id_name: data[cfg.id_name], "prediction": test_preds})
     (
         cfg.inference.submit_save_path
@@ -52,7 +53,7 @@ def make_submission_file(cfg, data: "pd.DataFrame", test_preds: np.ndarray):
     print(f"Submission file is saved to {sub_file}")
 
 
-def save_preds(cfg, data: "pd.DataFrame", test_preds: np.ndarray):
+def save_preds(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray):
     pred = pd.DataFrame({cfg.id_name: data[cfg.id_name], "mos": test_preds})
     if cfg.out_path is None:
         print("Predictions:")


### PR DESCRIPTION
## 🎯 Motivation
Currently, the `cfg` has no type annotation.

## 📝 Description of Changes

- Add the `Config` type to `_settings/_config.py`
- Update type annotations for all functions that takes `cfg` as an inputs
- Fixed Mypy errors in functions, including the constructor, that became fully annotated[^1] after introducing the `Config` type annotation


## 🔖 Additional Notes

Python 3.12 introduces the type statement [^2], so once Python 3.11 is dropped, current implementation using `TypeAlias` should be updated to use that instead.

Since we were prioritizing development speed while participating in the competition, `SimpleNamespace` were used. However, it would be better to refactor this and properly define the config type using `dataclass` or similar approaches.

[^1]: https://mypy.readthedocs.io/en/stable/class_basics.html#annotating-init-methods
[^2]: https://docs.python.org/3/whatsnew/3.12.html