### PR TITLE
Update README and remove `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,0 @@
-models/fusion_stage3/fold0_s42_best_model.pth filter=lfs diff=lfs merge=lfs -text
-models/fusion_stage3/fold1_s42_best_model.pth filter=lfs diff=lfs merge=lfs -text
-models/fusion_stage3/fold2_s42_best_model.pth filter=lfs diff=lfs merge=lfs -text
-models/fusion_stage3/fold3_s42_best_model.pth filter=lfs diff=lfs merge=lfs -text
-models/fusion_stage3/fold4_s42_best_model.pth filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -61,9 +61,6 @@
 
 ✨ You can easily use the pretrained UTMOSv2 model!
 
-> [!NOTE]
-> To clone the repository and use the pretrained UTMOSv2 model, make sure you have `git lfs` installed. If it is not installed, you can follow the instructions at [https://git-lfs.github.com/](https://git-lfs.github.com/) to install it.
-
 <h3 align="center">
   <div>🛠️ Using in your Python code 🛠️</div>
   <a href="https://github.com/sarulab-speech/UTMOSv2/tree/doc-user-friendly-api?tab=readme-ov-file#--%EF%B8%8F-using-in-your-python-code-%EF%B8%8F--------">
@@ -83,8 +80,7 @@ If you want to make predictions using the UTMOSv2 library, follow these steps:
 1. Install the UTMOSv2 library from GitHub
 
    ```bash
-   # Prevents LFS files from being temporarily downloaded during the installation process
-   GIT_LFS_SKIP_SMUDGE=1 pip install git+https://github.com/sarulab-speech/UTMOSv2.git
+   pip install git+https://github.com/sarulab-speech/UTMOSv2.git
    ```
 
 2. Make predictions


### PR DESCRIPTION
## 🎯 Motivation

This is a follow-up PR for this PR:
- #41.

While the original PR removed the models stored on GitHub, it does not update the documents or `.gitattributes`.

## 📝 Description of Changes

- Update README
- Remove `.gitattributes`


## 🔖 Additional Notes