### PR TITLE
Set `disallow_untyped_defs=true` and add missing type annotations

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -25,7 +25,7 @@ def main(cfg: Config) -> None:
     show_inference_data(data)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    cfg.print_config = True # type: ignore
+    cfg.print_config = True  # type: ignore
 
     test_preds = np.zeros(data.shape[0])
     if cfg.reproduce:
@@ -35,11 +35,11 @@ def main(cfg: Config) -> None:
         if 0 <= cfg.inference.fold < cfg.num_folds and fold != cfg.inference.fold:
             continue
 
-        cfg.now_fold = fold # type: ignore
+        cfg.now_fold = fold  # type: ignore
 
         model = get_model(cfg, device)
 
-        cfg.print_config = False # type: ignore
+        cfg.print_config = False  # type: ignore
         print(f"+*+*[[Fold {fold + 1}/{cfg.num_folds}]]" + "+*" * 30)
 
         for cycle in range(cfg.inference.num_tta):

--- a/inference.py
+++ b/inference.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 
 from utmosv2._settings import configure_defaults, configure_inference_args
+from utmosv2._settings._config import Config
 from utmosv2.runner import run_inference
 from utmosv2.utils import (
     get_dataloader,
@@ -19,25 +20,26 @@ from utmosv2.utils import (
 )
 
 
-def main(cfg):
+def main(cfg: Config) -> None:
     data = get_inference_data(cfg)
     show_inference_data(data)
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    cfg.print_config = True
+    cfg.print_config = True # type: ignore
 
     test_preds = np.zeros(data.shape[0])
-    test_metrics = {}
+    if cfg.reproduce:
+        test_metrics: dict[str, float] = {}
 
     for fold in range(cfg.num_folds):
         if 0 <= cfg.inference.fold < cfg.num_folds and fold != cfg.inference.fold:
             continue
 
-        cfg.now_fold = fold
+        cfg.now_fold = fold # type: ignore
 
         model = get_model(cfg, device)
 
-        cfg.print_config = False
+        cfg.print_config = False # type: ignore
         print(f"+*+*[[Fold {fold + 1}/{cfg.num_folds}]]" + "+*" * 30)
 
         for cycle in range(cfg.inference.num_tta):
@@ -48,6 +50,7 @@ def main(cfg):
             )
             test_preds += test_preds_tta
             if cfg.reproduce:
+                assert test_metrics_tta is not None
                 for k, v in test_metrics_tta.items():
                     test_metrics[k] = test_metrics.get(k, 0) + v
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,5 @@ include = ["utmosv2*"]
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true
+disallow_untyped_defs = true
 exclude = ["^build/"]

--- a/train.py
+++ b/train.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 import torch
+from utmosv2._settings._config import Config
 import wandb
 from dotenv import load_dotenv
 
@@ -23,7 +24,7 @@ from utmosv2.utils import (
 )
 
 
-def main(cfg):
+def main(cfg: Config) -> None:
     data = get_train_data(cfg)
     print(data.head())
     oof_preds = np.zeros(data.shape[0])
@@ -31,13 +32,13 @@ def main(cfg):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
 
-    cfg.print_config = True
+    cfg.print_config = True # type: ignore
 
     for fold, (train_idx, val_idx) in enumerate(split_data(cfg, data)):
         if 0 <= cfg.fold < cfg.num_folds and fold != cfg.fold:
             continue
 
-        cfg.now_fold = fold
+        cfg.now_fold = fold # type: ignore
 
         train_data = data.iloc[train_idx]
         val_data = data.iloc[val_idx]
@@ -56,7 +57,7 @@ def main(cfg):
             cfg, optimizer, len(train_dataloader) * cfg.run.num_epochs
         )
 
-        cfg.print_config = False
+        cfg.print_config = False # type: ignore
         print(f"+*+*[[Fold {fold + 1}/{cfg.num_folds}]]" + "+*" * 30)
         if cfg.wandb:
             wandb.init(

--- a/train.py
+++ b/train.py
@@ -32,13 +32,13 @@ def main(cfg: Config) -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
 
-    cfg.print_config = True # type: ignore
+    cfg.print_config = True  # type: ignore
 
     for fold, (train_idx, val_idx) in enumerate(split_data(cfg, data)):
         if 0 <= cfg.fold < cfg.num_folds and fold != cfg.fold:
             continue
 
-        cfg.now_fold = fold # type: ignore
+        cfg.now_fold = fold  # type: ignore
 
         train_data = data.iloc[train_idx]
         val_data = data.iloc[val_idx]
@@ -57,7 +57,7 @@ def main(cfg: Config) -> None:
             cfg, optimizer, len(train_dataloader) * cfg.run.num_epochs
         )
 
-        cfg.print_config = False # type: ignore
+        cfg.print_config = False  # type: ignore
         print(f"+*+*[[Fold {fold + 1}/{cfg.num_folds}]]" + "+*" * 30)
         if cfg.wandb:
             wandb.init(

--- a/utmosv2/_core/create.py
+++ b/utmosv2/_core/create.py
@@ -18,7 +18,7 @@ def create_model(
     fold: int = 0,
     checkpoint_path: Path | str | None = None,
     seed: int = 42,
-):
+) -> UTMOSv2Model:
     """
     Create a UTMOSv2 model with the specified configuration and optional pretrained weights.
 

--- a/utmosv2/_core/model/_common.py
+++ b/utmosv2/_core/model/_common.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import abc
 import warnings
 from pathlib import Path
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import numpy as np

--- a/utmosv2/_core/model/_common.py
+++ b/utmosv2/_core/model/_common.py
@@ -4,13 +4,14 @@ import abc
 import warnings
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
 from torch.cuda.amp import autocast
 from tqdm import tqdm
 
+from utmosv2._settings._config import Config
 from utmosv2.dataset._schema import DatasetSchema
 from utmosv2.utils import get_dataset
 
@@ -25,7 +26,7 @@ class UTMOSv2ModelMixin(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def _cfg(self) -> SimpleNamespace:
+    def _cfg(self) -> Config:
         pass
 
     @abc.abstractmethod
@@ -33,7 +34,7 @@ class UTMOSv2ModelMixin(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def __call__(self, *args, **kwargs) -> torch.Tensor:
+    def __call__(self, *args: Any, **kwargs: Any) -> torch.Tensor:
         pass
 
     def predict(

--- a/utmosv2/_core/model/_models.py
+++ b/utmosv2/_core/model/_models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import ModuleType, SimpleNamespace
 
 from utmosv2._core.model._common import UTMOSv2ModelMixin
+from utmosv2._settings._config import Config
 from utmosv2.model import (
     MultiSpecExtModel,
     MultiSpecModelV2,
@@ -10,6 +11,13 @@ from utmosv2.model import (
     SSLMultiSpecExtModelV1,
     SSLMultiSpecExtModelV2,
 )
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import torch
+    import torch.nn as nn
+
+
 
 
 class UTMOSv2Model(UTMOSv2ModelMixin):
@@ -18,7 +26,7 @@ class UTMOSv2Model(UTMOSv2ModelMixin):
     This class allows for flexible model selection and provides a unified interface for evaluation, calling, and prediction.
     """
 
-    def __init__(self, cfg: SimpleNamespace | ModuleType):
+    def __init__(self, cfg: Config):
         """
         Initialize the UTMOSv2Model with a specified configuration.
 
@@ -41,32 +49,32 @@ class UTMOSv2Model(UTMOSv2ModelMixin):
         self._cfg_value = cfg
 
     @property
-    def _cfg(self):
+    def _cfg(self) -> Config:
         return self._cfg_value
 
-    def eval(self):
+    def eval(self) -> "nn.Module":
         return self._model.eval()
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> "torch.Tensor":
         return self._model(*args, **kwargs)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         return getattr(self._model, name)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value: Any) -> None:
         if name == "_model":
             super().__setattr__(name, value)
         else:
             setattr(self._model, name, value)
 
-    def __delattr__(self, name):
+    def __delattr__(self, name: str) -> None:
         delattr(self._model, name)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"UTMOSv2Model({'('.join(self._model.__repr__().split('(')[1:])}"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
-    def __dir__(self):
-        return super().__dir__() + dir(self._model)
+    def __dir__(self) -> list[str]:
+        return super().__dir__() + self._model.__dir__()

--- a/utmosv2/_core/model/_models.py
+++ b/utmosv2/_core/model/_models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from types import ModuleType, SimpleNamespace
 
 from utmosv2._core.model._common import UTMOSv2ModelMixin
 from utmosv2._settings._config import Config
@@ -16,8 +15,6 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     import torch
     import torch.nn as nn
-
-
 
 
 class UTMOSv2Model(UTMOSv2ModelMixin):

--- a/utmosv2/_settings/_config.py
+++ b/utmosv2/_settings/_config.py
@@ -5,9 +5,10 @@ from typing import TypeAlias
 # NOTE: Python 3.12 introduces the type statement, so once Python 3.11 is dropped,
 # it should be updated to use that instead.
 Config: TypeAlias = SimpleNamespace | ModuleType
+import argparse
 
 
-def configure_args(cfg: Config, args) -> None:
+def configure_args(cfg: Config, args: argparse.Namespace) -> None:
     cfg.fold = args.fold  # type: ignore
     cfg.split.seed = args.seed  # type: ignore
     cfg.config_name = args.config  # type: ignore
@@ -21,7 +22,7 @@ def configure_args(cfg: Config, args) -> None:
     cfg.phase = "train"  # type: ignore
 
 
-def configure_inference_args(cfg: Config, args) -> None:
+def configure_inference_args(cfg: Config, args: argparse.Namespace) -> None:
     cfg.inference.fold = args.fold  # type: ignore
     cfg.split.seed = args.seed  # type: ignore
     cfg.config_name = args.config  # type: ignore

--- a/utmosv2/_settings/_config.py
+++ b/utmosv2/_settings/_config.py
@@ -7,7 +7,7 @@ from typing import TypeAlias
 Config: TypeAlias = SimpleNamespace | ModuleType
 
 
-def configure_args(cfg: Config, args):
+def configure_args(cfg: Config, args) -> None:
     cfg.fold = args.fold  # type: ignore
     cfg.split.seed = args.seed  # type: ignore
     cfg.config_name = args.config  # type: ignore
@@ -21,7 +21,7 @@ def configure_args(cfg: Config, args):
     cfg.phase = "train"  # type: ignore
 
 
-def configure_inference_args(cfg: Config, args):
+def configure_inference_args(cfg: Config, args) -> None:
     cfg.inference.fold = args.fold  # type: ignore
     cfg.split.seed = args.seed  # type: ignore
     cfg.config_name = args.config  # type: ignore
@@ -42,12 +42,12 @@ def configure_inference_args(cfg: Config, args):
     cfg.phase = "inference"  # type: ignore
 
 
-def configure_defaults(cfg: Config):
+def configure_defaults(cfg: Config) -> None:
     if cfg.id_name is None:
         cfg.id_name = "utt_id"  # type: ignore
 
 
-def configure_execution(cfg: Config):
+def configure_execution(cfg: Config) -> None:
     cfg.data_config = None  # type: ignore
     cfg.phase = "prediction"  # type: ignore
     cfg.print_config = False  # type: ignore

--- a/utmosv2/_settings/_config.py
+++ b/utmosv2/_settings/_config.py
@@ -1,3 +1,4 @@
+import argparse
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import TypeAlias
@@ -5,7 +6,6 @@ from typing import TypeAlias
 # NOTE: Python 3.12 introduces the type statement, so once Python 3.11 is dropped,
 # it should be updated to use that instead.
 Config: TypeAlias = SimpleNamespace | ModuleType
-import argparse
 
 
 def configure_args(cfg: Config, args: argparse.Namespace) -> None:

--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -31,5 +31,5 @@ class BaseDataset(torch.utils.data.Dataset, abc.ABC):
         return len(self.data)
 
     @abc.abstractmethod
-    def __getitem__(self, idx: int) -> tuple[torch.Tensor,...]:
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
         pass

--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -27,9 +27,9 @@ class BaseDataset(torch.utils.data.Dataset, abc.ABC):
         self.phase = phase
         self.transform = transform
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data)
 
     @abc.abstractmethod
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor,...]:
         pass

--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -20,7 +20,7 @@ class BaseDataset(torch.utils.data.Dataset, abc.ABC):
         cfg: Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
-        transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        transform: dict[str, Callable[[torch.Tensor], torch.Tensor]] | None = None,
     ):
         self.cfg = cfg
         self.data = data

--- a/utmosv2/dataset/_utils.py
+++ b/utmosv2/dataset/_utils.py
@@ -52,5 +52,5 @@ def get_dataset_map(cfg: Config) -> dict[str, int]:
         }
 
 
-def get_dataset_num(cfg) -> int:
+def get_dataset_num(cfg: Config) -> int:
     return len(get_dataset_map(cfg))

--- a/utmosv2/dataset/_utils.py
+++ b/utmosv2/dataset/_utils.py
@@ -32,7 +32,7 @@ def select_random_start(y: np.ndarray, length: int) -> np.ndarray:
     return y[start : start + length]
 
 
-def get_dataset_map(cfg: Config):
+def get_dataset_map(cfg: Config) -> dict[str, int]:
     if cfg.data_config:
         with open(cfg.data_config, "r") as f:
             datasets = json.load(f)
@@ -52,5 +52,5 @@ def get_dataset_map(cfg: Config):
         }
 
 
-def get_dataset_num(cfg):
+def get_dataset_num(cfg) -> int:
     return len(get_dataset_map(cfg))

--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -35,7 +35,7 @@ class MultiSpecDataset(BaseDataset):
         transform (Callable[[torch.Tensor], torch.Tensor] | None): Transformation function to apply to spectrograms.
     """
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
         """
         Get the spectrogram and target MOS for a given index.
 
@@ -102,7 +102,7 @@ class MultiSpecExtDataset(MultiSpecDataset):
         super().__init__(cfg, data, phase, transform)
         self.dataset_map = get_dataset_map(cfg)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
         """
         Get the spectrogram, data-domain embedding, and target MOS for a given index.
 
@@ -123,7 +123,7 @@ class MultiSpecExtDataset(MultiSpecDataset):
         return spec, d, target
 
 
-def _make_spctrogram(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
+def _make_spctrogram(cfg: Config, spec_cfg: Config, y: np.ndarray) -> np.ndarray:
     if spec_cfg.mode == "melspec":
         return _make_melspec(cfg, spec_cfg, y)
     elif spec_cfg.mode == "stft":
@@ -132,7 +132,7 @@ def _make_spctrogram(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
         raise NotImplementedError
 
 
-def _make_melspec(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
+def _make_melspec(cfg: Config, spec_cfg: Config, y: np.ndarray) -> np.ndarray:
     spec = librosa.feature.melspectrogram(
         y=y,
         sr=cfg.sr,
@@ -147,7 +147,7 @@ def _make_melspec(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
     return spec
 
 
-def _make_stft(cfg: Config, spec_cfg, y: np.ndarray) -> np.ndarray:
+def _make_stft(cfg: Config, spec_cfg: Config, y: np.ndarray) -> np.ndarray:
     spec = librosa.stft(y=y, n_fft=spec_cfg.n_fft, hop_length=spec_cfg.hop_length)
     spec = np.abs(spec)
     spec = librosa.amplitude_to_db(spec)

--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -32,7 +32,7 @@ class MultiSpecDataset(BaseDataset):
         cfg (SimpleNamespace): The configuration object containing dataset and model settings.
         data (list[DatasetSchema] | pd.DataFrame): The dataset containing file paths and labels.
         phase (str): The phase of the dataset, either "train" or any other phase (e.g., "valid").
-        transform (Callable[[torch.Tensor], torch.Tensor] | None): Transformation function to apply to spectrograms.
+        transform (str, dict[Callable[[torch.Tensor], torch.Tensor]] | None): Transformation function to apply to spectrograms.
     """
 
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
@@ -65,16 +65,17 @@ class MultiSpecDataset(BaseDataset):
                     spec = lmd * spec + (1 - lmd) * spec2
                 spec = np.stack([spec, spec, spec], axis=0)
                 # spec = np.transpose(spec, (1, 2, 0))
-                spec = torch.tensor(spec, dtype=torch.float32)
+                spec_tensor = torch.tensor(spec, dtype=torch.float32)
                 phase = "train" if self.phase == "train" else "valid"
-                spec = self.transform[phase](spec)
-                specs.append(spec)
-        spec = torch.stack(specs).float()
+                assert self.transform is not None, "Transform must be provided."
+                spec_tensor = self.transform[phase](spec_tensor)
+                specs.append(spec_tensor)
+        spec_tensor = torch.stack(specs).float()
 
         target = row.mos or 0.0
         target = torch.tensor(target, dtype=torch.float32)
 
-        return spec, target
+        return spec_tensor, target
 
 
 class MultiSpecExtDataset(MultiSpecDataset):
@@ -88,7 +89,7 @@ class MultiSpecExtDataset(MultiSpecDataset):
             The dataset containing file paths and labels.
         phase (str):
             The phase of the dataset, either "train" or any other phase (e.g., "valid").
-        transform (Callable[[torch.Tensor], torch.Tensor] | None):
+        transform (dict[str, Callable[[torch.Tensor], torch.Tensor]] | None):
             Transformation function to apply to spectrograms.
     """
 
@@ -97,7 +98,7 @@ class MultiSpecExtDataset(MultiSpecDataset):
         cfg: Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
-        transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        transform: dict[str, Callable[[torch.Tensor], torch.Tensor]] | None = None,
     ):
         super().__init__(cfg, data, phase, transform)
         self.dataset_map = get_dataset_map(cfg)
@@ -118,9 +119,9 @@ class MultiSpecExtDataset(MultiSpecDataset):
 
         d = np.zeros(len(self.dataset_map))
         d[self.dataset_map[row.dataset]] = 1
-        d = torch.tensor(d, dtype=torch.float32)
+        dt = torch.tensor(d, dtype=torch.float32)
 
-        return spec, d, target
+        return spec, dt, target
 
 
 def _make_spctrogram(cfg: Config, spec_cfg: Config, y: np.ndarray) -> np.ndarray:

--- a/utmosv2/dataset/ssl.py
+++ b/utmosv2/dataset/ssl.py
@@ -71,7 +71,9 @@ class SSLExtDataset(SSLDataset):
             The phase of the dataset, either "train" or any other phase (e.g., "valid").
     """
 
-    def __init__(self, cfg: Config, data: "pd.DataFrame" | list[DatasetSchema], phase: str):
+    def __init__(
+        self, cfg: Config, data: "pd.DataFrame" | list[DatasetSchema], phase: str
+    ):
         super().__init__(cfg, data, phase)
         self.dataset_map = get_dataset_map(cfg)
 

--- a/utmosv2/dataset/ssl_multispec.py
+++ b/utmosv2/dataset/ssl_multispec.py
@@ -28,7 +28,7 @@ class SSLLMultiSpecExtDataset(BaseDataset):
             The dataset containing file paths and MOS labels.
         phase (str):
             The phase of the dataset, either "train" or any other phase (e.g., "valid").
-        transform (Callable[[torch.Tensor], torch.Tensor] | None):
+        transform (dict[str, Callable[[torch.Tensor], torch.Tensor]] | None):
             Transformation function to apply to spectrograms.
     """
 
@@ -37,16 +37,16 @@ class SSLLMultiSpecExtDataset(BaseDataset):
         cfg: Config,
         data: "pd.DataFrame" | list[DatasetSchema],
         phase: str,
-        transform: Callable[[torch.Tensor], torch.Tensor] | None = None,
+        transform: dict[str, Callable[[torch.Tensor], torch.Tensor]] | None = None,
     ):
         super().__init__(cfg, data, phase, transform)
         self.ssl = SSLExtDataset(cfg, data, phase)
         self.multi_spec = MultiSpecDataset(cfg, data, phase, transform)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data)
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx: int) -> tuple[torch.Tensor, ...]:
         """
         Get data for SSL feature extractor, mel-spectrogram feature extractor, data-domain embedding, and target MOS for a given index.
 

--- a/utmosv2/model/multi_spec.py
+++ b/utmosv2/model/multi_spec.py
@@ -70,7 +70,7 @@ class MultiSpecModelV2(nn.Module):
         #     print(f"| Number of fc input features: {self.fc.in_features}")
         #     print(f"| Number of fc output features: {self.fc.out_features}")
 
-    def forward(self, x):
+    def forward(self, x) -> torch.Tensor:
         """
         Forward pass of the MultiSpecModelV2.
 
@@ -179,7 +179,7 @@ class MultiSpecExtModel(nn.Module):
         #     print(f"| Number of fc input features: {self.fc.in_features}")
         #     print(f"| Number of fc output features: {self.fc.out_features}")
 
-    def forward(self, x, d):
+    def forward(self, x, d) -> torch.Tensor:
         x = [
             x[:, i, :, :, :].squeeze(1)
             for i in range(

--- a/utmosv2/model/multi_spec.py
+++ b/utmosv2/model/multi_spec.py
@@ -70,7 +70,7 @@ class MultiSpecModelV2(nn.Module):
         #     print(f"| Number of fc input features: {self.fc.in_features}")
         #     print(f"| Number of fc output features: {self.fc.out_features}")
 
-    def forward(self, x) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass of the MultiSpecModelV2.
 
@@ -82,25 +82,25 @@ class MultiSpecModelV2(nn.Module):
             torch.Tensor:
                 Output tensor after applying backbones, pooling, and fully connected layers.
         """
-        x = [
+        xl = [
             x[:, i, :, :, :].squeeze(1)
             for i in range(
                 self.cfg.dataset.spec_frames.num_frames * len(self.cfg.dataset.specs)
             )
         ]
-        x = [
-            self.backbones[i % len(self.cfg.dataset.specs)](t) for i, t in enumerate(x)
+        xl = [
+            self.backbones[i % len(self.cfg.dataset.specs)](t) for i, t in enumerate(xl)
         ]
-        x = [
+        xl = [
             sum(
                 [
-                    x[i * len(self.cfg.dataset.specs) + j] * w
+                    xl[i * len(self.cfg.dataset.specs) + j] * w
                     for j, w in enumerate(self.weights)
                 ]
             )
             for i in range(self.cfg.dataset.spec_frames.num_frames)
         ]
-        x = torch.cat(x, dim=3)
+        x = torch.cat(xl, dim=3)
         x = self.pooling(x).squeeze(3)
         if self.cfg.model.multi_spec.atten:
             xt = torch.permute(x, (0, 2, 1))
@@ -169,7 +169,7 @@ class MultiSpecExtModel(nn.Module):
 
         self.num_dataset = get_dataset_num(cfg)
 
-        self.fc = nn.Linear(
+        self.fc: nn.Linear | nn.Identity = nn.Linear(
             fc_in_features + self.num_dataset, cfg.model.multi_spec.num_classes
         )
 
@@ -179,26 +179,26 @@ class MultiSpecExtModel(nn.Module):
         #     print(f"| Number of fc input features: {self.fc.in_features}")
         #     print(f"| Number of fc output features: {self.fc.out_features}")
 
-    def forward(self, x, d) -> torch.Tensor:
-        x = [
+    def forward(self, x: torch.Tensor, d: torch.Tensor) -> torch.Tensor:
+        xl = [
             x[:, i, :, :, :].squeeze(1)
             for i in range(
                 self.cfg.dataset.spec_frames.num_frames * len(self.cfg.dataset.specs)
             )
         ]
-        x = [
-            self.backbones[i % len(self.cfg.dataset.specs)](t) for i, t in enumerate(x)
+        xl = [
+            self.backbones[i % len(self.cfg.dataset.specs)](t) for i, t in enumerate(xl)
         ]
-        x = [
+        xl = [
             sum(
                 [
-                    x[i * len(self.cfg.dataset.specs) + j] * w
+                    xl[i * len(self.cfg.dataset.specs) + j] * w
                     for j, w in enumerate(self.weights)
                 ]
             )
             for i in range(self.cfg.dataset.spec_frames.num_frames)
         ]
-        x = torch.cat(x, dim=3)
+        x = torch.cat(xl, dim=3)
         x = self.pooling(x).squeeze(3)
         if self.cfg.model.multi_spec.atten:
             xt = torch.permute(x, (0, 2, 1))

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -19,7 +19,7 @@ class _SSLEncoder(nn.Module):
             for param in self.model.parameters():
                 param.requires_grad = False
 
-    def forward(self, x) -> tuple[torch.Tensor]:
+    def forward(self, x: tuple[torch.Tensor]) -> tuple[torch.Tensor]:
         x = self.processor(
             [t.cpu().numpy() for t in x],
             sampling_rate=self.sr,
@@ -67,7 +67,7 @@ class SSLExtModel(nn.Module):
             in_features * 2 + self.num_dataset, cfg.model.ssl.num_classes
         )
 
-    def forward(self, x, d) -> torch.Tensor:
+    def forward(self, x: tuple[torch.Tenfsor], d: torch.Tensor) -> torch.Tensor:
         """
         Forward pass of the SSLExtModel.
 

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -82,7 +82,7 @@ class SSLExtModel(nn.Module):
                 Output tensor after applying the SSL encoder, attention (if configured), and fully connected layers.
         """
         xt = self.encoder(xt)
-        x: torch.Tensor = sum([t * w for t, w in zip(x, self.weights)])
+        x: torch.Tensor = sum([t * w for t, w in zip(xt, self.weights)])
         if self.cfg.model.ssl.attn:
             y = x
             for attn in self.attn:

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -67,7 +67,7 @@ class SSLExtModel(nn.Module):
             in_features * 2 + self.num_dataset, cfg.model.ssl.num_classes
         )
 
-    def forward(self, x: tuple[torch.Tenfsor], d: torch.Tensor) -> torch.Tensor:
+    def forward(self, xt: tuple[torch.Tensor], d: torch.Tensor) -> torch.Tensor:
         """
         Forward pass of the SSLExtModel.
 
@@ -81,8 +81,8 @@ class SSLExtModel(nn.Module):
             torch.Tensor:
                 Output tensor after applying the SSL encoder, attention (if configured), and fully connected layers.
         """
-        x = self.encoder(x)
-        x = sum([t * w for t, w in zip(x, self.weights)])
+        xt = self.encoder(xt)
+        x: torch.Tensor = sum([t * w for t, w in zip(x, self.weights)])
         if self.cfg.model.ssl.attn:
             y = x
             for attn in self.attn:

--- a/utmosv2/model/ssl.py
+++ b/utmosv2/model/ssl.py
@@ -19,7 +19,7 @@ class _SSLEncoder(nn.Module):
             for param in self.model.parameters():
                 param.requires_grad = False
 
-    def forward(self, x):
+    def forward(self, x) -> tuple[torch.Tensor]:
         x = self.processor(
             [t.cpu().numpy() for t in x],
             sampling_rate=self.sr,
@@ -67,7 +67,7 @@ class SSLExtModel(nn.Module):
             in_features * 2 + self.num_dataset, cfg.model.ssl.num_classes
         )
 
-    def forward(self, x, d):
+    def forward(self, x, d) -> torch.Tensor:
         """
         Forward pass of the SSLExtModel.
 

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -40,7 +40,9 @@ class SSLMultiSpecExtModelV1(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1: torch.Tensor, x2: torch.Tensor, d: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x1: torch.Tensor, x2: torch.Tensor, d: torch.Tensor
+    ) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(x2)
         x = torch.cat([x1, x2, d], dim=1)
@@ -83,7 +85,9 @@ class SSLMultiSpecExtModelV2(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1: torch.Tensor, x2: torch.Tensor, d: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x1: torch.Tensor, x2: torch.Tensor, d: torch.Tensor
+    ) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(
             x2, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device)

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -40,7 +40,7 @@ class SSLMultiSpecExtModelV1(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1: tuple[torch.Tendor], x2: tuple[torch.Tensor], d: torch.Tensor) -> torch.Tensor:
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor, d: torch.Tensor) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(x2)
         x = torch.cat([x1, x2, d], dim=1)
@@ -49,7 +49,7 @@ class SSLMultiSpecExtModelV1(nn.Module):
 
 
 class SSLMultiSpecExtModelV2(nn.Module):
-    def __init__(self, cfg):
+    def __init__(self, cfg: Config):
         super().__init__()
         self.cfg = cfg
         self.ssl = SSLExtModel(cfg)
@@ -83,7 +83,7 @@ class SSLMultiSpecExtModelV2(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1, x2, d) -> torch.Tensor:
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor, d: torch.Tensor) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(
             x2, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device)

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -40,7 +40,7 @@ class SSLMultiSpecExtModelV1(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1, x2, d):
+    def forward(self, x1, x2, d) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(x2)
         x = torch.cat([x1, x2, d], dim=1)
@@ -83,7 +83,7 @@ class SSLMultiSpecExtModelV2(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1, x2, d):
+    def forward(self, x1, x2, d) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(
             x2, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device)

--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -40,7 +40,7 @@ class SSLMultiSpecExtModelV1(nn.Module):
             cfg.model.ssl_spec.num_classes,
         )
 
-    def forward(self, x1, x2, d) -> torch.Tensor:
+    def forward(self, x1: tuple[torch.Tendor], x2: tuple[torch.Tensor], d: torch.Tensor) -> torch.Tensor:
         x1 = self.ssl(x1, torch.zeros(x1.shape[0], self.num_dataset).to(x1.device))
         x2 = self.spec_long(x2)
         x = torch.cat([x1, x2, d], dim=1)

--- a/utmosv2/preprocess/_preprocess.py
+++ b/utmosv2/preprocess/_preprocess.py
@@ -28,7 +28,9 @@ def _clip_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> N
         )
 
 
-def _select_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> "pd.DataFrame":
+def _select_audio(
+    cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"
+) -> "pd.DataFrame":
     if cfg.preprocess.min_seconds is None:
         return data
     select_file_name = f"min_seconds={cfg.preprocess.min_seconds}.txt"
@@ -65,7 +67,9 @@ def _clip_and_select_audio(
     return data
 
 
-def _change_file_path(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> None:
+def _change_file_path(
+    cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"
+) -> None:
     data.loc[:, "file_path"] = data.loc[:, "file_path"].apply(
         lambda x: cfg.preprocess.save_path
         / data_name

--- a/utmosv2/preprocess/_preprocess.py
+++ b/utmosv2/preprocess/_preprocess.py
@@ -15,7 +15,7 @@ else:
     pd = _LazyImport("pandas")
 
 
-def _clip_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
+def _clip_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> None:
     (cfg.preprocess.save_path / data_name).mkdir(parents=True, exist_ok=True)
     for file in tqdm(data["file_path"].values, desc="Clipping audio files"):
         y, _ = librosa.load(file, sr=None)
@@ -28,7 +28,7 @@ def _clip_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
         )
 
 
-def _select_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
+def _select_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> None:
     if cfg.preprocess.min_seconds is None:
         return data
     select_file_name = f"min_seconds={cfg.preprocess.min_seconds}.txt"
@@ -65,7 +65,7 @@ def _clip_and_select_audio(
     return data
 
 
-def _change_file_path(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"):
+def _change_file_path(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> None:
     data.loc[:, "file_path"] = data.loc[:, "file_path"].apply(
         lambda x: cfg.preprocess.save_path
         / data_name
@@ -73,7 +73,7 @@ def _change_file_path(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc"
     )
 
 
-def _add_metadata(cfg: Config, data: "pd.DataFrame"):
+def _add_metadata(cfg: Config, data: "pd.DataFrame") -> None:
     metadata = []
     for t in ["TRAINSET", "DEVSET", "TESTSET"]:
         meta = pd.read_csv(cfg.input_dir / f"sets/{t}")
@@ -85,7 +85,7 @@ def _add_metadata(cfg: Config, data: "pd.DataFrame"):
     data["sys_id"] = dt["sys_id"]
 
 
-def add_sys_mean(data: "pd.DataFrame"):
+def add_sys_mean(data: "pd.DataFrame") -> None:
     sys_mean = (
         data.groupby("sys_id", as_index=False)["mos"].mean().reset_index(drop=True)
     )

--- a/utmosv2/preprocess/_preprocess.py
+++ b/utmosv2/preprocess/_preprocess.py
@@ -28,7 +28,7 @@ def _clip_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> N
         )
 
 
-def _select_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> None:
+def _select_audio(cfg: Config, data: "pd.DataFrame", data_name: str = "bvcc") -> "pd.DataFrame":
     if cfg.preprocess.min_seconds is None:
         return data
     select_file_name = f"min_seconds={cfg.preprocess.min_seconds}.txt"

--- a/utmosv2/utils/_pure/metrics.py
+++ b/utmosv2/utils/_pure/metrics.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-def print_metrics(metrics: dict[str, float]):
+def print_metrics(metrics: dict[str, float]) -> None:
     """
     Print the given metrics in a formatted string.
 

--- a/utmosv2/utils/_pure/save.py
+++ b/utmosv2/utils/_pure/save.py
@@ -11,13 +11,8 @@ else:
 
 
 def save_oof_preds(
-<<<<<<< HEAD
     cfg: Config, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int
-):
-=======
-    cfg, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int
 ) -> None:
->>>>>>> 649bc59 (Add missing type annotations)
     """
     Save out-of-fold (OOF) predictions to a CSV file.
 

--- a/utmosv2/utils/_pure/save.py
+++ b/utmosv2/utils/_pure/save.py
@@ -11,8 +11,13 @@ else:
 
 
 def save_oof_preds(
+<<<<<<< HEAD
     cfg: Config, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int
 ):
+=======
+    cfg, data: "pd.DataFrame", oof_preds: "np.ndarray", fold: int
+) -> None:
+>>>>>>> 649bc59 (Add missing type annotations)
     """
     Save out-of-fold (OOF) predictions to a CSV file.
 

--- a/utmosv2/utils/_task_dependents/initializers.py
+++ b/utmosv2/utils/_task_dependents/initializers.py
@@ -184,11 +184,16 @@ def _get_test_save_name(cfg: Config) -> str:
 
 
 def save_test_preds(
+<<<<<<< HEAD
     cfg: Config,
     data: "pd.DataFrame",
     test_preds: np.ndarray,
     test_metrics: dict[str, float],
 ):
+=======
+    cfg, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
+) -> None:
+>>>>>>> 649bc59 (Add missing type annotations)
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)
     save_path = (

--- a/utmosv2/utils/_task_dependents/initializers.py
+++ b/utmosv2/utils/_task_dependents/initializers.py
@@ -184,16 +184,11 @@ def _get_test_save_name(cfg: Config) -> str:
 
 
 def save_test_preds(
-<<<<<<< HEAD
     cfg: Config,
     data: "pd.DataFrame",
     test_preds: np.ndarray,
     test_metrics: dict[str, float],
-):
-=======
-    cfg, data: "pd.DataFrame", test_preds: np.ndarray, test_metrics: dict[str, float]
 ) -> None:
->>>>>>> 649bc59 (Add missing type annotations)
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)
     save_path = (

--- a/utmosv2/utils/_task_dependents/log.py
+++ b/utmosv2/utils/_task_dependents/log.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
 
-def show_inference_data(data: "pd.DataFrame"):
+def show_inference_data(data: "pd.DataFrame") -> None:
     print(
         data[[c for c in data.columns if c != "mos"]]
         .rename(columns={"dataset": "predict_dataset"})

--- a/utmosv2/utils/_task_dependents/save.py
+++ b/utmosv2/utils/_task_dependents/save.py
@@ -37,7 +37,9 @@ def save_test_preds(
     print(f"Test predictions are saved to {save_path}")
 
 
-def make_submission_file(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray) -> None:
+def make_submission_file(
+    cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray
+) -> None:
     submit = pd.DataFrame({cfg.id_name: data[cfg.id_name], "prediction": test_preds})
     (
         cfg.inference.submit_save_path

--- a/utmosv2/utils/_task_dependents/save.py
+++ b/utmosv2/utils/_task_dependents/save.py
@@ -20,7 +20,7 @@ def save_test_preds(
     data: "pd.DataFrame",
     test_preds: np.ndarray,
     test_metrics: dict[str, float],
-):
+) -> None:
     test_df = pd.DataFrame({cfg.id_name: data[cfg.id_name], "test_preds": test_preds})
     cfg.inference.save_path.mkdir(parents=True, exist_ok=True)
     save_path = (
@@ -37,7 +37,7 @@ def save_test_preds(
     print(f"Test predictions are saved to {save_path}")
 
 
-def make_submission_file(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray):
+def make_submission_file(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray) -> None:
     submit = pd.DataFrame({cfg.id_name: data[cfg.id_name], "prediction": test_preds})
     (
         cfg.inference.submit_save_path
@@ -56,7 +56,7 @@ def make_submission_file(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarr
     print(f"Submission file is saved to {sub_file}")
 
 
-def save_preds(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray):
+def save_preds(cfg: Config, data: "pd.DataFrame", test_preds: np.ndarray) -> None:
     pred = pd.DataFrame({cfg.id_name: data[cfg.id_name], "mos": test_preds})
     if cfg.out_path is None:
         print("Predictions:")


### PR DESCRIPTION
## 🎯 Motivation

Currently, some methods and functions lack sufficient type annotations, causing them to be treated as untyped and ignored by Mypy.

## 📝 Description of Changes

- Set `disallow_untyped_defs=true` for Mypy
- Update type annotations


## 🔖 Additional Notes