### PR TITLE
Rename BaseDataset to _BaseDataset for internal use

### DIFF
--- a/utmosv2/dataset/_base.py
+++ b/utmosv2/dataset/_base.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from utmosv2.dataset._schema import DatasetSchema
 
 
-class BaseDataset(torch.utils.data.Dataset, abc.ABC):
+class _BaseDataset(torch.utils.data.Dataset, abc.ABC):
     def __init__(
         self,
         cfg: Config,

--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -8,7 +8,7 @@ import numpy as np
 import torch
 
 from utmosv2._settings._config import Config
-from utmosv2.dataset._base import BaseDataset
+from utmosv2.dataset._base import _BaseDataset
 from utmosv2.dataset._utils import (
     extend_audio,
     get_dataset_map,
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from utmosv2.dataset._schema import DatasetSchema
 
 
-class MultiSpecDataset(BaseDataset):
+class MultiSpecDataset(_BaseDataset):
     """
     Dataset class for mel-spectrogram feature extractor. This class is responsible for
     loading audio data, generating multiple spectrograms for each sample, and

--- a/utmosv2/dataset/ssl.py
+++ b/utmosv2/dataset/ssl.py
@@ -6,7 +6,7 @@ import numpy as np
 import torch
 
 from utmosv2._settings._config import Config
-from utmosv2.dataset._base import BaseDataset
+from utmosv2.dataset._base import _BaseDataset
 from utmosv2.dataset._utils import (
     extend_audio,
     get_dataset_map,
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from utmosv2.dataset._schema import DatasetSchema
 
 
-class SSLDataset(BaseDataset):
+class SSLDataset(_BaseDataset):
     """
     Dataset class for SSL (Self-Supervised Learning) feature extractor.
     This class handles audio loading, extending, and random selection of a segment from the audio.

--- a/utmosv2/dataset/ssl_multispec.py
+++ b/utmosv2/dataset/ssl_multispec.py
@@ -7,7 +7,7 @@ import torch
 
 from utmosv2._settings._config import Config
 from utmosv2.dataset import MultiSpecDataset, SSLExtDataset
-from utmosv2.dataset._base import BaseDataset
+from utmosv2.dataset._base import _BaseDataset
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from utmosv2.dataset._schema import DatasetSchema
 
 
-class SSLLMultiSpecExtDataset(BaseDataset):
+class SSLLMultiSpecExtDataset(_BaseDataset):
     """
     Dataset class that combines both SSL (Self-Supervised Learning) and Multi-Spectrogram datasets.
     This dataset uses both SSLExtDataset and MultiSpecDataset to provide different representations


### PR DESCRIPTION
## 🎯 Motivation

`BaseDataset` is intended for internal use, but does not currently start with an under score.


## 📝 Description of Changes
- Renaming `BaseDataset` to `_BaseDataset` to clarify that it is for internal use.


## 🔖 Additional Notes