### PR TITLE
Update torch installation for the CPU-only version in CI

### DIFF
--- a/.github/workflows/mypy_check.yml
+++ b/.github/workflows/mypy_check.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install -U pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install --progress-bar off -U .[check]
 
       - name: Mypy Check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install -U pip
-        pip install torch --index-url https://download.pytorch.org/whl/cpu
+        pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off -U .[test]
 
     - name: Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Install
       run: |
         python -m pip install -U pip
+        pip install torch --index-url https://download.pytorch.org/whl/cpu
         pip install --progress-bar off -U .[test]
 
     - name: Test


### PR DESCRIPTION
## 🎯 Motivation

Since CI does not need the GPU version of torch, we can save installation time by specifying the CPU-only version.


## 📝 Description of Changes

- Add torch installation ahead of utmosv2 installation

## 🔖 Additional Notes

> [!NOTE]
> As we can see from [here](https://pytorch.org/get-started/locally/), the GPU version of torch is installed by default on Linux machine.