### PR TITLE
Move pretrained models to HF Models

### DIFF
--- a/utmosv2/utils/_download.py
+++ b/utmosv2/utils/_download.py
@@ -38,7 +38,7 @@ def download_pretrained_weights_from_hf(cfg_name: str, now_fold: int) -> None:
     if cfg_name != "fusion_stage3":
         raise ValueError(f"{cfg_name} is not stored.")
     print(f"Downloading pretrained weights for `{cfg_name}`...")
-    url = f"https://huggingface.co/spaces/sarulab-speech/UTMOSv2/resolve/main/models/{cfg_name}/fold{now_fold}_s42_best_model.pth"
+    url = f"https://huggingface.co/sarulab-speech/UTMOSv2/resolve/main/fold{now_fold}_s42_best_model.pth"
     try:
         subprocess.run(
             [


### PR DESCRIPTION
## 🎯 Motivation

This PR is related to this PR:
- #41.

That PR removed pre-trained weights from GitHub, and now they are being downloaded from HF Spaces. To improve organization, we have created a new repository on HF Models to store these weights, so the download process has been updated to pull from this new location instead.

## 📝 Description of Changes

- Updated the download URL from HF Spaces to HF Models

## 🔖 Additional Notes