### PR TITLE
Add optional utility `remove_silent_section` for users

### DIFF
--- a/utmosv2/dataset/multi_spec.py
+++ b/utmosv2/dataset/multi_spec.py
@@ -15,6 +15,7 @@ from utmosv2.dataset._utils import (
     load_audio,
     select_random_start,
 )
+from utmosv2.preprocess._preprocess import remove_silent_section
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -48,6 +49,11 @@ class MultiSpecDataset(_BaseDataset):
         row = self.data[idx] if isinstance(self.data, list) else self.data.iloc[idx]
         file = row.file_path
         y = load_audio(self.cfg, file)
+        if (
+            hasattr(self.cfg.dataset, "remove_silent_section")
+            and self.cfg.dataset.remove_silent_section
+        ):
+            y = remove_silent_section(y)
         specs = []
         length = int(self.cfg.dataset.spec_frames.frame_sec * self.cfg.sr)
         y = extend_audio(self.cfg, y, length, type=self.cfg.dataset.spec_frames.extend)

--- a/utmosv2/dataset/ssl.py
+++ b/utmosv2/dataset/ssl.py
@@ -13,6 +13,7 @@ from utmosv2.dataset._utils import (
     load_audio,
     select_random_start,
 )
+from utmosv2.preprocess._preprocess import remove_silent_section
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -48,6 +49,11 @@ class SSLDataset(_BaseDataset):
         row = self.data[idx] if isinstance(self.data, list) else self.data.iloc[idx]
         file = row.file_path
         y = load_audio(self.cfg, file)
+        if (
+            hasattr(self.cfg.dataset, "remove_silent_section")
+            and self.cfg.dataset.remove_silent_section
+        ):
+            y = remove_silent_section(y)
         length = int(self.cfg.dataset.ssl.duration * self.cfg.sr)
         y = extend_audio(self.cfg, y, length, type="tile")
         y = select_random_start(y, length)

--- a/utmosv2/preprocess/__init__.py
+++ b/utmosv2/preprocess/__init__.py
@@ -1,3 +1,8 @@
-from utmosv2.preprocess._preprocess import add_sys_mean, preprocess, preprocess_test
+from utmosv2.preprocess._preprocess import (
+    add_sys_mean,
+    preprocess,
+    preprocess_test,
+    remove_silent_section,
+)
 
-__all__ = ["preprocess", "preprocess_test", "add_sys_mean"]
+__all__ = ["add_sys_mean", "preprocess", "preprocess_test", "remove_silent_section"]


### PR DESCRIPTION
## 🎯 Motivation

This PR is related to:
- #56.

When the user's input contains a lot of silence, removing these sections might be needed. So I'll include this preprocessing as an optional utility for users. 

## 📝 Description of Changes

- Add `remove_silent_section`


## 🔖 Additional Notes

A preprocessing step to remove silent sections longer than `min_length` can be written as follows without using any for loop:
```python
def remove_silent_section(audio: np.ndarray, min_length: int = 4800) -> np.ndarray:
    mask = audio > 0.1
    mask = np.pad(mask, (1, 0)) ^ np.pad(mask, (0, 1))
    indices = np.where(mask)[0][1:]
    length = (indices[1:] - indices[:-1])[::2]
    indices_mask = np.pad(np.repeat(length > min_length, 2), (0, 1))
    indices = indices[indices_mask]
    mask2 = np.zeros_like(audio, dtype=int)
    mask2[indices] = np.where(np.arange(indices.shape[0]) % 2, -1, 1)
    mask2 = np.cumsum(mask2).astype(bool)
    return audio[~mask2]
```