### PR TITLE
Skip loading indivisual component weight when the fusion model weight is specified

### DIFF
--- a/utmosv2/model/ssl_multispec.py
+++ b/utmosv2/model/ssl_multispec.py
@@ -57,13 +57,13 @@ class SSLMultiSpecExtModelV2(nn.Module):
         self.cfg = cfg
         self.ssl = SSLExtModel(cfg)
         self.spec_long = MultiSpecExtModel(cfg)
-        if cfg.model.ssl_spec.ssl_weight is not None and cfg.phase == "train":
+        if cfg.model.ssl_spec.ssl_weight and cfg.phase == "train" and not cfg.weight:
             self.ssl.load_state_dict(
                 torch.load(
                     f"outputs/{cfg.model.ssl_spec.ssl_weight}/fold{cfg.now_fold}_s{cfg.split.seed}_best_model.pth"
                 )
             )
-        if cfg.model.ssl_spec.spec_weight is not None and cfg.phase == "train":
+        if cfg.model.ssl_spec.spec_weight and cfg.phase == "train" and not cfg.weight:
             self.spec_long.load_state_dict(
                 torch.load(
                     f"outputs/{cfg.model.ssl_spec.spec_weight}/fold{cfg.now_fold}_s{cfg.split.seed}_best_model.pth"


### PR DESCRIPTION
## 🎯 Motivation

This PR aims to:
- resolve #63.

When fine-tuning the fusion model from its pre-trained weights, there is no need to prepare individual SSL and spec models, as their component weights will be overridden.
This makes it more convenient for users who want to fine-tune the fusion model without training the SSL and spec model itself.

## 📝 Description of Changes

- Update the condition for loading each component weight.


## 🔖 Additional Notes