### PR TITLE
Relax torch version requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.24.4",
-    "torch>=2.3.1",
+    "torch>=2.1.1",
     "timm>=1.0.7",
     "librosa>=0.10.2",
     "tqdm>=4.66.4",


### PR DESCRIPTION
## 🎯 Motivation

- Resolve https://github.com/sarulab-speech/UTMOSv2/issues/71

## 📝 Description of Changes

- Update torch version constraint from `>=2.3.1` to `>=2.1.1`

## 🔖 Additional Notes

> [!NOTE]
> We cannot relax it to `>=2.0.1`, since [`torch.nn.utils.weight_norm`](https://pytorch.org/docs/stable/generated/torch.nn.utils.weight_norm.html) has been deprecated and moved to [`torch.nn.utils.parametrizations.weight_norm`](https://pytorch.org/docs/stable/generated/torch.nn.utils.parametrizations.weight_norm.html).