### PR TITLE
remove audio file whitelist, fallback to numpy load if audio can't be read by librosa backend

### DIFF
--- a/utmosv2/dataset/_utils.py
+++ b/utmosv2/dataset/_utils.py
@@ -11,7 +11,7 @@ def load_audio(cfg: Config, file: Path) -> np.ndarray:
     try:
         y, sr = librosa.load(file, sr=None)
         y = librosa.resample(y, orig_sr=sr, target_sr=cfg.sr)
-    except RuntimeError:
+    except Exception:
         y = np.load(file)
     return y
 


### PR DESCRIPTION
## Motivation
A separate audio file extension check prevents this library from working with files that librosa supports but aren't enumerated.  For example, even though librosa.load supports mp3 and ogg files, the current impl thinks it should fall back to loading a numpy pickle object from the file and fails.

## Changes
Instead, try loading the specified path and fall back to loading the file from numpy if that fails. Librosa generally throws `soundfile.LibsndfileError` when trying to read a file it doesn't understand. To avoid another import, check the superclass RuntimeError instead.

## Testing

Setup
```
from utmosv2.dataset._utils import load_audio
from pathlib import Path
from dataclasses import dataclass
@dataclass
class MockCfg:
     sr: int = 16000
```

Before (cryptic error):
```
>>> load_audio(MockCfg(), Path("/home/tkanarsky/tmp/podcast_lex_10min.mp3"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tkanarsky/.local/lib/python3.11/site-packages/utmosv2/dataset/_utils.py", line 15, in load_audio
    y = np.load(file)
        ^^^^^^^^^^^^^
  File ".../lib/python3.11/site-packages/numpy/lib/npyio.py", line 462, in load
    raise ValueError("Cannot load file containing pickled data "
ValueError: Cannot load file containing pickled data when allow_pickle=False
```
After:
```
>>> load_audio(MockCfg(), Path("/home/tkanarsky/tmp/podcast_lex_10min.mp3"))
array([ 0.        ,  0.        ,  0.        , ..., -0.0364641 ,
       -0.03225256, -0.0289182 ], dtype=float32)
```